### PR TITLE
Bundle SVG spritesheet with JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ a few things, but it will do them well.
 [CesiumJS]: https://github.com/AnalyticalGraphicsInc/cesium
 
 ## Installation
-For module bundlers, GlobeletJS is provided as an ESM import.
-First install the package:
+GlobeletJS is provided as an ESM import.
+
+On Node.js, first install the package:
 ```bash
 npm install --save globeletjs
 ```
@@ -32,10 +33,24 @@ Then import it into your Javascript file:
 import * as globelet from 'globeletjs';
 ```
 
-Globelet also uses two additional files, which you will need to copy into the
-same directory as your HTML file. These are found in the /dist folder:
-- globelet.css
-- globelet.svg
+Or if you are importing directly into a browser:
+```html
+<script type="module">
+  import * as globelet from "https://unpkg.com/globeletjs@<VERSION>/dist/globelet.js";
+
+  // Initialize globe here...
+  // ...
+</script>
+```
+
+Make sure to also link to the stylesheet (/dist/globelet.js) in the `<head>`
+of your HTML file.
+```html
+<link 
+  rel="stylesheet" 
+  type="text/css" 
+  href="https://unpkg.com/globeletjs@<VERSION>/dist/globelet.css">
+```
 
 ## Syntax
 The imported object has a method that can initialize a new globe as follows:

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -1,11 +1,13 @@
 import resolve from '@rollup/plugin-node-resolve';
 import json from '@rollup/plugin-json';
+import { svg } from "./svg-plugin.js";
 import pkg from "../package.json";
 
 export default {
   input: 'src/main.js',
   plugins: [
     resolve(),
+    svg(),
     json(),
   ],
   output: {

--- a/build/svg-plugin.js
+++ b/build/svg-plugin.js
@@ -1,0 +1,15 @@
+// Plugin for .svg files
+export function svg() {
+  return { transform };
+}
+
+function transform(source, id) {
+  // Confirm filename extension is .svg
+  if (/\.svg$/.test(id) === false) return;
+
+  // Return as template literal
+  return {
+    code: "export default `" + source + "`",
+    map: { mappings: '' }, // No map
+  };
+}

--- a/dist/globelet.css
+++ b/dist/globelet.css
@@ -38,6 +38,13 @@
   position: absolute;
   padding: 0;
 }
+.slider .sprite {
+  width: 0;
+  height: 0;
+  position: absolute;
+  visibility: hidden;
+  display: none;
+}
 .slider .settings {
   position: absolute;
   width: var(--settingwidth);

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -485,11 +485,69 @@ function initContext(gl) {
 
 var version = "0.0.1";
 
+var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="sprite">
+  <!--Default image for favicon-->
+  <text y="1em" font-size="80">&#127823;</text>
+
+  <!--Spritesheet symbols: not displayed unless "used"-->
+  <symbol id="hamburger" viewBox="0 0 100 70">
+    <rect width="100" height="10" />
+    <rect width="100" height="10" y="30" />
+    <rect width="100" height="10" y="60" />
+  </symbol>
+
+  <symbol id="close" viewBox="0 0 32 32">
+    <line x1="2" y1="2" x2="30" y2="30" />
+    <line x1="2" y1="30" x2="30" y2="2" />
+  </symbol>
+
+  <symbol id="gt" viewBox="0 0 32 32">
+    <line x1="8" y1="2" x2="24" y2="16" />
+    <line x1="24" y1="16" x2="8" y2="30" />
+  </symbol>
+
+  <symbol id="gear" viewBox="0 0 400 400">
+    <!--https://observablehq.com/@jjhembd/gear-icon-generator-->
+    <path d="M390.00,200.00
+      L386.35,237.07L329.16,247.95L311.63,280.75L334.35,334.35
+      L305.56,357.98L257.42,325.23L221.83,336.03L200.00,390.00
+      L162.93,386.35L152.05,329.16L119.25,311.63L65.65,334.35
+      L42.02,305.56L74.77,257.42L63.97,221.83L10.00,200.00
+      L13.65,162.93L70.84,152.05L88.37,119.25L65.65,65.65
+      L94.44,42.02L142.58,74.77L178.17,63.97L200.00,10.00
+      L237.07,13.65L247.95,70.84L280.75,88.37L334.35,65.65
+      L357.98,94.44L325.23,142.58L336.03,178.17z
+      M285.54,200.00A85.54,85.54,0,1,0,285.54,200.27z" />
+  </symbol>
+
+  <symbol id="marker" viewBox="0 0 24 24">
+    <!-- Follows baseline-place-24px.svg from 
+         https://material.io/tools/icons/?icon=place&style=baseline -->
+    <path d="M12,2
+      C8.13,2 5,5.13 5,9
+      c0,5.25 7,13 7,13
+      s7,-7.75 7,-13
+      c0,-3.87 -3.13,-7 -7,-7z
+      m0,9.5
+      c-1.38,0 -2.5,-1.12 -2.5,-2.5
+      s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z" />
+  </symbol>
+
+  <symbol id="spot" viewBox="0 0 12 12">
+    <circle cx="6" cy="6" r="5" />
+  </symbol>
+</svg>
+`;
+
 function setParams$2(userParams) {
   const container = document.getElementById(userParams.container);
+
+  // Append svg sprite for later reference from 'use' elements
+  container.insertAdjacentHTML('afterbegin', sprite);
+
+  // Get user-supplied parameters
   const {
     style, mapboxToken,
-    svgPath = "https://unpkg.com/globeletjs@" + version + "/dist/globelet.svg",
     width: rawWidth = container.clientWidth + 512,
     height: rawHeight = container.clientHeight + 512,
     toolTip,
@@ -510,7 +568,7 @@ function setParams$2(userParams) {
   const context = initContext(gl);
 
   return {
-    style, mapboxToken, svgPath,
+    style, mapboxToken, version,
     width, height,
     container, context,
     toolTip: document.getElementById(toolTip),
@@ -11534,7 +11592,7 @@ function degMinSec( radians ) {
   return deg + "&#176;" + min + "'" + sec + '"';
 }
 
-function initMarkers(globe, { container, svgPath }) {
+function initMarkers(globe, container) {
   const markerList = [];
 
   return {
@@ -11572,7 +11630,8 @@ function initMarkers(globe, { container, svgPath }) {
     svg.setAttribute("class", type);
 
     const use = document.createElementNS(svgNS, "use");
-    use.setAttribute("href", svgPath + "#" + type);
+    // Reference the relevant sprite from the SVG appended in params.js
+    use.setAttribute("href", "#" + type);
     svg.appendChild(use);
 
     return svg;
@@ -11616,7 +11675,7 @@ function setup(map, params) {
     map: map.texture,
     flipY: false,
   });
-  const markers = initMarkers(ball, params);
+  const markers = initMarkers(ball, params.container);
 
   return {
     mapLoaded: map.loaded,

--- a/dist/globelet.svg
+++ b/dist/globelet.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="sprite">
   <!--Default image for favicon-->
   <text y="1em" font-size="80">&#127823;</text>
 

--- a/examples/geojson/index.html
+++ b/examples/geojson/index.html
@@ -26,7 +26,6 @@
       container: 'globe',
       toolTip: 'toolTip',
       style: "./klokantech-basic-style-geojson.json",
-      svgPath: "../../dist/globelet.svg",
       center: [-100, 38.5],
       altitude: 6280,
     }).then(globe => {

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ function setup(map, params) {
     flipY: false,
   });
   const eventHandler = initEventHandler();
-  const markers = initMarkers(ball, params);
+  const markers = initMarkers(ball, params.container);
 
   return {
     mapLoaded: map.loaded,

--- a/src/markers.js
+++ b/src/markers.js
@@ -1,4 +1,4 @@
-export function initMarkers(globe, { container, svgPath }) {
+export function initMarkers(globe, container) {
   const markerList = [];
 
   return {
@@ -36,7 +36,8 @@ export function initMarkers(globe, { container, svgPath }) {
     svg.setAttribute("class", type);
 
     const use = document.createElementNS(svgNS, "use");
-    use.setAttribute("href", svgPath + "#" + type);
+    // Reference the relevant sprite from the SVG appended in params.js
+    use.setAttribute("href", "#" + type);
     svg.appendChild(use);
 
     return svg;

--- a/src/params.js
+++ b/src/params.js
@@ -1,11 +1,16 @@
 import * as yawgl from 'yawgl';
 import { version } from "../package.json";
+import sprite from "../dist/globelet.svg";
 
 export function setParams(userParams) {
   const container = document.getElementById(userParams.container);
+
+  // Append svg sprite for later reference from 'use' elements
+  container.insertAdjacentHTML('afterbegin', sprite);
+
+  // Get user-supplied parameters
   const {
     style, mapboxToken,
-    svgPath = "https://unpkg.com/globeletjs@" + version + "/dist/globelet.svg",
     width: rawWidth = container.clientWidth + 512,
     height: rawHeight = container.clientHeight + 512,
     toolTip,
@@ -26,7 +31,7 @@ export function setParams(userParams) {
   const context = yawgl.initContext(gl);
 
   return {
-    style, mapboxToken, svgPath,
+    style, mapboxToken, version,
     width, height,
     container, context,
     toolTip: document.getElementById(toolTip),


### PR DESCRIPTION
Here is another approach to solve the problem addressed by #2.

The entire globelet.svg file is bundled into globelet.js as a [template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals), and appended to the container HTML element. Default markers now simply reference the relevant sprite by its ID, from the current document. Users do not need to think about globelet.svg at all.

The dist folder still includes the original globelet.svg file for now, in case some of the buttons are needed for custom menus, popups, etc. This may need to be revisited once we address the first point in #1.