### PR TITLE
Create required HTML in params.js, to simplify setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ globe as follows:
 const params = {
   container: 'globe',
   style: "./klokantech-basic-style-geojson.json",
-  toolTip: 'toolTip',
   center: [-100, 38.5],
   altitude: 6280,
 };
@@ -76,8 +75,6 @@ The `params` object supplied to initGlobe can have the following properties:
   in pixels. Defaults to `container.clientWidth + 512`
 - `height`: The height of the map that will be projected onto the globe,
   in pixels. Defaults to `container.clientHeight + 512`
-- `toolTip`: The [ID][] of an [HTML DIV element][] that will display the
-  current longitude, latitude, and altitude of the camera
 - `center`: The initial geographic position of the camera, given as
   [longitude, latitude] in degrees. Default: [0.0, 0.0]
 - `altitude`: The initial altitude of the camera, in kilometers.

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -543,17 +543,26 @@ var globeletjs = (function (exports) {
 `;
 
   function setParams$2(userParams) {
+    // Get the containing DIV element, and set its CSS class
     const container = document.getElementById(userParams.container);
+    container.classList.add("globelet");
 
-    // Append svg sprite for later reference from 'use' elements
-    container.insertAdjacentHTML('afterbegin', sprite);
+    // Add Elements for globe interface, svg sprite, status bar, canvas
+    const globeDiv = addChild("div", "main", container);
+    globeDiv.id = "globe"; // TEMPORARY: For backwards compatibility
+    globeDiv.insertAdjacentHTML('afterbegin', sprite);
+    const toolTip = addChild("div", "status", globeDiv);
+    const canvas = addChild("canvas", "map", globeDiv);
+
+    // Get a WebGL context and add yawgl functionality
+    const gl = getExtendedContext(canvas);
+    const context = initContext(gl);
 
     // Get user-supplied parameters
     const {
       style, mapboxToken,
-      width: rawWidth = container.clientWidth + 512,
-      height: rawHeight = container.clientHeight + 512,
-      toolTip,
+      width: rawWidth = globeDiv.clientWidth + 512,
+      height: rawHeight = globeDiv.clientHeight + 512,
       center = [0.0, 0.0],
       altitude = 20000,
     } = userParams;
@@ -563,20 +572,18 @@ var globeletjs = (function (exports) {
     const height = nextPowerOf2(rawHeight);
     const width = Math.max(nextPowerOf2(rawWidth), height);
 
-    // Create a Canvas with a WebGL context
-    const canvas = document.createElement('canvas');
-    canvas.className = "map";
-    container.appendChild(canvas);
-    const gl = getExtendedContext(canvas);
-    const context = initContext(gl);
-
-    return {
-      style, mapboxToken, version,
+    return { version,
+      style, mapboxToken,
       width, height,
-      container, context,
-      toolTip: document.getElementById(toolTip),
+      globeDiv, context, toolTip,
       center, altitude,
     };
+
+    function addChild(tagName, className, parentElement) {
+      const child = document.createElement(tagName);
+      child.className = className;
+      return parentElement.appendChild(child);
+    }
   }
 
   // Maximum latitude for Web Mercator: 85.0113 degrees. Beware rounding!
@@ -11626,7 +11633,7 @@ precision highp sampler2D;
         : createSVG(type);
     }
 
-    function createSVG(type) {
+    function createSVG(type = "marker") {
       const svgNS = "http://www.w3.org/2000/svg";
 
       const svg = document.createElementNS(svgNS, "svg");
@@ -11671,14 +11678,14 @@ precision highp sampler2D;
   function setup(map, params) {
     var requestID;
 
-    const ball = init$1(params.container, params.center, params.altitude);
+    const ball = init$1(params.globeDiv, params.center, params.altitude);
     const satView = init({
       context: params.context,
       globeRadius: ball.radius(),
       map: map.texture,
       flipY: false,
     });
-    const markers = initMarkers(ball, params.container);
+    const markers = initMarkers(ball, params.globeDiv);
 
     return {
       mapLoaded: map.loaded,
@@ -11699,7 +11706,7 @@ precision highp sampler2D;
       addMarker: markers.add,
       removeMarker: markers.remove,
 
-      destroy: satView.destroy,
+      destroy: () => (satView.destroy(), params.globeDiv.remove()),
       breakLoop: 0,
     };
 

--- a/dist/globelet.css
+++ b/dist/globelet.css
@@ -1,4 +1,4 @@
-.slider {
+.globelet {
   --settingwidth: min(480px, 100vw);
   --infowidth: min(480px, 50vw);
   --xslide: min(480px, 50vw);
@@ -6,20 +6,20 @@
   --yslide: 0px;
 }
 @media screen and (max-width: 768px) and (orientation: portrait) {
-  .slider {
+  .globelet {
     --infowidth: 100%;
     --xslide: 0px;
     --menuheight: 50vh;
     --yslide: 50vh;
   }
 }
-.slider * {
+.globelet * {
   box-sizing: border-box;
 }
-.slider div {
+.globelet div {
   transition: 0.33s;
 }
-.slider button {
+.globelet button {
   background: transparent;
   border: none;
   padding: 8px;
@@ -28,24 +28,24 @@
   -webkit-appearance: none;
   touch-action: manipulation;
 }
-.slider button svg {
+.globelet button svg {
   touch-action: manipulation;
 }
-.slider canvas.map {
+.globelet canvas.map {
   width: 100%;
   height: 100%;
   display: inline-block;
   position: absolute;
   padding: 0;
 }
-.slider .sprite {
+.globelet .sprite {
   width: 0;
   height: 0;
   position: absolute;
   visibility: hidden;
   display: none;
 }
-.slider .settings {
+.globelet .settings {
   position: absolute;
   width: var(--settingwidth);
   height: 100%;
@@ -53,14 +53,17 @@
   visibility: hidden; /* Hide from tab navigation when offscreen */
   z-index: 2;
 }
-.slider .main {
+.globelet .main {
   width: 100%;
   height: 100%;
+  position: relative;
+  overflow: hidden;
+  background-color: #404542;
 }
-.slider .shifted {
+.globelet .shifted {
   transform: translate(calc(0px - var(--xslide) / 2), calc(0px - var(--yslide) / 2));
 }
-.slider .infobox {
+.globelet .infobox {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -70,11 +73,11 @@
   visibility: hidden; /* Hide from tab navigation when offscreen */
   z-index: 1;
 }
-.slider .slid {
+.globelet .slid {
   visibility: visible;
   transform: translate(0px);
 }
-.slider .status {
+.globelet .status {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -85,23 +88,23 @@
   padding: 0.2em;
   z-index: 1;
 }
-.slider .icon {
+.globelet .icon {
   width: 20px;
   height: 20px;
 }
-.slider .stroke {
+.globelet .stroke {
   stroke: grey;
   stroke-width: 2;
 }
-.slider .stroke:hover {
+.globelet .stroke:hover {
   stroke: black;
 }
-.slider .close-button {
+.globelet .close-button {
   position: absolute;
   top: 0;
   right: 0;
 }
-.slider .marker {
+.globelet .marker {
   display: inline-block;
   position: absolute;
   z-index: 1;
@@ -110,7 +113,7 @@
   transform: translate(-50%, -96%);
   stroke: white;
 }
-.slider .spot {
+.globelet .spot {
   display: inline-block;
   position: absolute;
   z-index: 1;

--- a/examples/geojson/index.html
+++ b/examples/geojson/index.html
@@ -12,20 +12,14 @@
   </head>
 
   <body>
-    <div class="slider">
-      <div class="main" id="globe">
-        <div class="status" id="toolTip"></div>
-      </div>
-    </div>
+    <div id="globe"></div>
   </body>
 
-  <!--<script src="../../dist/globelet-iife.js"></script>-->
   <script type="module">
     import * as globeletjs from "../../dist/globelet.js";
 
     globeletjs.initGlobe({
       container: 'globe',
-      toolTip: 'toolTip',
       style: "./klokantech-basic-style-geojson.json",
       center: [-100, 38.5],
       altitude: 6280,

--- a/examples/geojson/styles.css
+++ b/examples/geojson/styles.css
@@ -9,12 +9,7 @@ body {
   touch-action: none;
   overscroll-behavior: none;
 }
-.slider .main {
-  background-color: #404542;
-  position: relative;
-  overflow: hidden;
-}
-.slider .spot {
+.globelet .spot {
   width: 18px;
   height: 18px;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ export function initGlobe(userParams) {
 function setup(map, params) {
   var requestID;
 
-  const ball = spinningBall.init(params.container, params.center, params.altitude);
+  const ball = spinningBall.init(params.globeDiv, params.center, params.altitude);
   const satView = satelliteView.init({
     context: params.context,
     globeRadius: ball.radius(),
@@ -25,7 +25,7 @@ function setup(map, params) {
     flipY: false,
   });
   const eventHandler = initEventHandler();
-  const markers = initMarkers(ball, params.container);
+  const markers = initMarkers(ball, params.globeDiv);
 
   return {
     mapLoaded: map.loaded,
@@ -46,7 +46,7 @@ function setup(map, params) {
     addMarker: markers.add,
     removeMarker: markers.remove,
 
-    destroy: satView.destroy,
+    destroy: () => (satView.destroy(), params.globeDiv.remove()),
     breakLoop: 0,
   };
 

--- a/src/markers.js
+++ b/src/markers.js
@@ -29,7 +29,7 @@ export function initMarkers(globe, container) {
       : createSVG(type);
   }
 
-  function createSVG(type) {
+  function createSVG(type = "marker") {
     const svgNS = "http://www.w3.org/2000/svg";
 
     const svg = document.createElementNS(svgNS, "svg");

--- a/src/params.js
+++ b/src/params.js
@@ -3,17 +3,26 @@ import { version } from "../package.json";
 import sprite from "../dist/globelet.svg";
 
 export function setParams(userParams) {
+  // Get the containing DIV element, and set its CSS class
   const container = document.getElementById(userParams.container);
+  container.classList.add("globelet");
 
-  // Append svg sprite for later reference from 'use' elements
-  container.insertAdjacentHTML('afterbegin', sprite);
+  // Add Elements for globe interface, svg sprite, status bar, canvas
+  const globeDiv = addChild("div", "main", container);
+  globeDiv.id = "globe"; // TEMPORARY: For backwards compatibility
+  globeDiv.insertAdjacentHTML('afterbegin', sprite);
+  const toolTip = addChild("div", "status", globeDiv);
+  const canvas = addChild("canvas", "map", globeDiv);
+
+  // Get a WebGL context and add yawgl functionality
+  const gl = yawgl.getExtendedContext(canvas);
+  const context = yawgl.initContext(gl);
 
   // Get user-supplied parameters
   const {
     style, mapboxToken,
-    width: rawWidth = container.clientWidth + 512,
-    height: rawHeight = container.clientHeight + 512,
-    toolTip,
+    width: rawWidth = globeDiv.clientWidth + 512,
+    height: rawHeight = globeDiv.clientHeight + 512,
     center = [0.0, 0.0],
     altitude = 20000,
   } = userParams;
@@ -23,18 +32,16 @@ export function setParams(userParams) {
   const height = nextPowerOf2(rawHeight);
   const width = Math.max(nextPowerOf2(rawWidth), height);
 
-  // Create a Canvas with a WebGL context
-  const canvas = document.createElement('canvas');
-  canvas.className = "map";
-  container.appendChild(canvas);
-  const gl = yawgl.getExtendedContext(canvas);
-  const context = yawgl.initContext(gl);
-
-  return {
-    style, mapboxToken, version,
+  return { version,
+    style, mapboxToken,
     width, height,
-    container, context,
-    toolTip: document.getElementById(toolTip),
+    globeDiv, context, toolTip,
     center, altitude,
   };
+
+  function addChild(tagName, className, parentElement) {
+    const child = document.createElement(tagName);
+    child.className = className;
+    return parentElement.appendChild(child);
+  }
 }


### PR DESCRIPTION
With this PR, the user only needs to supply the ID of one DIV. The required child DIVs (for the globe display and the toolTip) are then created when GlobeletJS initializes. GlobeletJS also adds the required CSS classes.

This should address the first point in #1.

Note how much simpler the HTML is in examples/geojson/index.html.
Old:
```html
<body>
  <div class="slider">
    <div class="main" id="globe">
      <div class="status" id="toolTip"></div>
    </div>
  </div>
</body>
````

New:
```html
<body>
  <div id="globe"></div>
</body>
```

File changes:
- params.js: Create HTML nodes with appropriate CSS classes for
  main globe DIV and toolTip
- markers.js: Set default marker type
- main.js: Update HTML node name, and remove globeDiv in destroy
  method
- dist/globelet.css: Rename base class to "globelet", and add
  default styles for main globe DIV
- examples/geojson: Simplify index.html and styles.css
- README.md: Remove reference to toolTip div (now auto-generated)