### PR TITLE
Improve documentation and errors for problems with the map style

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ const globePromise = globeletjs.initGlobe(params);
 The `params` object supplied to initGlobe can have the following properties:
 - `container` (REQUIRED): The [ID][] of an [HTML DIV element][] where the 
   globe will be displayed
-- `style` (REQUIRED): A link to a [Mapbox style document][] describing the map 
-  to be rendered
+- `style` (REQUIRED): A link to a [MapLibre style document][Maplibre] 
+  describing the map to be rendered. Please see below for some notes about
+  [supported map styles](#supported-map-styles).
 - `mapboxToken`: Your API token for Mapbox services (if needed)
 - `width`: The width of the map that will be projected onto the globe,
   in pixels. Defaults to `container.clientWidth + 512`
@@ -85,7 +86,7 @@ with the globe, as described in the next section.
 
 [ID]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
 [HTML DIV element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
-[Mapbox style document]: https://docs.mapbox.com/mapbox-gl-js/style-spec/
+[MapLibre]: https://maplibre.org/maplibre-gl-js-docs/style-spec/
 
 ## How to interact with the globe API
 The Promise returned by `initGlobe` resolves to an API object, which you can
@@ -154,6 +155,23 @@ A marker can be removed from the globe as follows:
 ```javascript
 globeAPI.removeMarker(marker);
 ```
+
+## Supported map styles
+Many features described in the [style specification][MapLibre] are not yet
+supported. This is partly by design--GlobeletJS is intended to be an 80/20
+map solution, implementing 80% of the specification with 20% as much code as
+other software. But we are adding support for more features over time.
+
+The map rendering is delegated to the [tile-setter][] module, which is
+limited by some of its dependencies. See the ["un-supported features" list for
+tile-stencil][tile-stencil-limitations] and the [tile-gl TODO list][tile-gl-todo]
+for an (incomplete) list of what is not supported.
+
+We welcome your feedback on what additional features you would like to see
+supported!
+
+[tile-stencil-limitations]: https://github.com/GlobeletJS/tile-stencil#un-supported-features
+[tile-gl-todo]: https://github.com/GlobeletJS/tile-gl#todo
 
 ## About the code (for advanced users)
 For development on Node.js, you can install the package from NPM:

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -9030,7 +9030,7 @@ function sendTile(id, tile) {
    * @returns {vec3} a new 3D vector
    */
 
-  function create() {
+  function create$2() {
     var out = new ARRAY_TYPE(3);
 
     if (ARRAY_TYPE != Float32Array) {
@@ -9176,7 +9176,7 @@ function sendTile(id, tile) {
    * @returns {vec3} out
    */
 
-  function transformMat4(out, a, m) {
+  function transformMat4$1(out, a, m) {
     var x = a[0],
         y = a[1],
         z = a[2];
@@ -9219,7 +9219,7 @@ function sendTile(id, tile) {
    */
 
   (function () {
-    var vec = create();
+    var vec = create$2();
     return function (a, stride, offset, count, fn, arg) {
       var i, l;
 
@@ -9249,7 +9249,7 @@ function sendTile(id, tile) {
 
       return a;
     };
-  }());
+  })();
 
   function initEcefToLocalGeo() {
     var sinLon, cosLon, sinLat, cosLat;
@@ -9685,7 +9685,7 @@ function sendTile(id, tile) {
    * @returns {vec4} a new 4D vector
    */
 
-  function create$2() {
+  function create() {
     var out = new ARRAY_TYPE(4);
 
     if (ARRAY_TYPE != Float32Array) {
@@ -9706,7 +9706,7 @@ function sendTile(id, tile) {
    * @returns {vec4} out
    */
 
-  function transformMat4$1(out, a, m) {
+  function transformMat4(out, a, m) {
     var x = a[0],
         y = a[1],
         z = a[2],
@@ -9731,7 +9731,7 @@ function sendTile(id, tile) {
    */
 
   (function () {
-    var vec = create$2();
+    var vec = create();
     return function (a, stride, offset, count, fn, arg) {
       var i, l;
 
@@ -9763,7 +9763,7 @@ function sendTile(id, tile) {
 
       return a;
     };
-  }());
+  })();
 
   function initEdgePoints(ellipsoid, camPos, camRot, screen) {
     // Allocate working arrays and variables
@@ -9816,7 +9816,7 @@ function sendTile(id, tile) {
       rayVec[0] = screenPos[0] * tanX;
       rayVec[1] = screenPos[1] * tanY;
       // Rotate to model coordinates (Earth-Centered Earth-Fixed)
-      transformMat4$1(camRay, rayVec, camRot);
+      transformMat4(camRay, rayVec, camRot);
 
       // Find intersection of ray with ellipsoid
       var hit = ellipsoid.shoot(rayHit, camPos, camRay);
@@ -10053,7 +10053,7 @@ function sendTile(id, tile) {
       const visible = ( dot(rayVec, ecefPosition) < 0 );
 
       // Rotate to camera orientation
-      transformMat4(screenRay, rayVec, camInverse);
+      transformMat4$1(screenRay, rayVec, camInverse);
 
       // Normalize to z = -1
       screenRay[0] /= -screenRay[2];
@@ -10152,7 +10152,7 @@ function sendTile(id, tile) {
   }
 
   function initCursor3d(getRayParams, ellipsoid, initialPosition) {
-    // Input getRayParams is a method from yawgl.screen, converting screen X/Y
+    // Input getRayParams is a method from yawgl.initView, converting screen X/Y
     //  to a ray shooting into 3D space
     // Input initialPosition is a geodetic lon/lat/alt vector
 
@@ -10209,7 +10209,7 @@ function sendTile(id, tile) {
     function update(cursor2d, camera) {
       // Get screen ray in model coordinates (ECEF)
       getRayParams(cursorRay, cursor2d.x(), cursor2d.y());
-      transformMat4$1(ecefRay, cursorRay, camera.rotation);
+      transformMat4(ecefRay, cursorRay, camera.rotation);
 
       // Find intersection of ray with ellipsoid
       onScene = ellipsoid.shoot(cursorPosition, camera.ecefPos, ecefRay);

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -542,7 +542,7 @@ var globeletjs = (function (exports) {
 </svg>
 `;
 
-  function setParams$2(userParams) {
+  function setParams$3(userParams) {
     // Get the containing DIV element, and set its CSS class
     const container = document.getElementById(userParams.container);
     container.classList.add("globelet");
@@ -794,7 +794,7 @@ vec4 mapToClip(vec2 mapPos, float z) {
 }
 `;
 
-  var vert = `attribute vec2 quadPos; // Vertices of the quad instance
+  var vert$3 = `attribute vec2 quadPos; // Vertices of the quad instance
 attribute vec2 circlePos;
 attribute float radius;
 attribute vec4 color;
@@ -819,7 +819,7 @@ void main() {
 }
 `;
 
-  var frag = `precision mediump float;
+  var frag$3 = `precision mediump float;
 
 varying vec2 delta;
 varying vec4 strokeStyle;
@@ -919,7 +919,7 @@ void main() {
   function initCircle(context, framebufferSize, preamble) {
     const { initProgram, initQuad, initAttribute } = context;
 
-    const program = initProgram(preamble + vert, frag);
+    const program = initProgram(preamble + vert$3, frag$3);
     const { use, uniformSetters, constructVao } = program;
 
     const grid = initGrid(framebufferSize, use, uniformSetters);
@@ -960,7 +960,7 @@ void main() {
     return { load, initPainter };
   }
 
-  var vert$1 = `attribute vec2 quadPos;
+  var vert$2 = `attribute vec2 quadPos;
 attribute vec3 pointA, pointB, pointC, pointD;
 attribute vec4 color;
 attribute float opacity;
@@ -1038,7 +1038,7 @@ void main() {
 }
 `;
 
-  var frag$1 = `precision highp float;
+  var frag$2 = `precision highp float;
 
 uniform float lineWidth;
 
@@ -1117,7 +1117,7 @@ void main() {
   }
 
   function initLine(context, framebufferSize, preamble) {
-    const program = context.initProgram(preamble + vert$1, frag$1);
+    const program = context.initProgram(preamble + vert$2, frag$2);
     const { use, uniformSetters, constructVao } = program;
 
     const grid = initGrid(framebufferSize, use, uniformSetters);
@@ -1147,7 +1147,7 @@ void main() {
     return { load, initPainter };
   }
 
-  var vert$2 = `attribute vec2 position;
+  var vert$1 = `attribute vec2 position;
 attribute vec4 color;
 attribute float opacity;
 
@@ -1164,7 +1164,7 @@ void main() {
 }
 `;
 
-  var frag$2 = `precision mediump float;
+  var frag$1 = `precision mediump float;
 
 varying vec4 fillStyle;
 
@@ -1199,7 +1199,7 @@ void main() {
   }
 
   function initFill(context, framebufferSize, preamble) {
-    const program = context.initProgram(preamble + vert$2, frag$2);
+    const program = context.initProgram(preamble + vert$1, frag$1);
     const { use, uniformSetters, constructVao } = program;
     const grid = initGrid(framebufferSize, use, uniformSetters);
 
@@ -1220,7 +1220,7 @@ void main() {
     return { load, initPainter };
   }
 
-  var vert$3 = `attribute vec2 quadPos;  // Vertices of the quad instance
+  var vert = `attribute vec2 quadPos;  // Vertices of the quad instance
 attribute vec2 labelPos; // x, y
 attribute vec3 charPos;  // dx, dy, scale (relative to labelPos)
 attribute vec4 sdfRect;  // x, y, w, h
@@ -1244,7 +1244,7 @@ void main() {
 }
 `;
 
-  var frag$3 = `precision highp float;
+  var frag = `precision highp float;
 
 uniform sampler2D sdf;
 uniform vec2 sdfDim;
@@ -1292,7 +1292,7 @@ void main() {
   }
 
   function initText(context, framebufferSize, preamble) {
-    const program = context.initProgram(preamble + vert$3, frag$3);
+    const program = context.initProgram(preamble + vert, frag);
     const { use, uniformSetters, constructVao } = program;
     const grid = initGrid(framebufferSize, use, uniformSetters);
 
@@ -1413,7 +1413,7 @@ void main() {
   function setParams$1(userParams) {
     const gl = userParams.context.gl;
     if (!(gl instanceof WebGLRenderingContext)) {
-      fail("no valid WebGL context");
+      fail$1("no valid WebGL context");
     }
 
     const {
@@ -1429,28 +1429,28 @@ void main() {
 
     const { buffer, size } = framebuffer;
     if (!(buffer instanceof WebGLFramebuffer) && buffer !== null) {
-      fail("no valid framebuffer");
+      fail$1("no valid framebuffer");
     }
 
     if (!size || !allPosInts(size.width, size.height)) {
-      fail("invalid size object");
+      fail$1("invalid size object");
     }
 
     if (!Array.isArray(center) || center.length < 2) {
-      fail("invalid center coordinates");
+      fail$1("invalid center coordinates");
     }
 
     if (!Number.isFinite(zoom)) {
-      fail("invalid zoom value");
+      fail$1("invalid zoom value");
     }
 
     const validUnits = ["degrees", "radians", "xy"];
-    if (!validUnits.includes(units)) fail("invalid units");
+    if (!validUnits.includes(units)) fail$1("invalid units");
     const projection = getProjection(units);
 
     // Convert initial center position from degrees to the specified units
     const projCenter = getProjection("degrees").forward(center);
-    if (!all0to1(...projCenter)) fail ("invalid center coordinates");
+    if (!all0to1(...projCenter)) fail$1 ("invalid center coordinates");
     const invCenter = projection.inverse(projCenter);
 
     return {
@@ -1463,7 +1463,7 @@ void main() {
     };
   }
 
-  function fail(message) {
+  function fail$1(message) {
     throw Error("tile-setter parameter check: " + message + "!");
   }
 
@@ -1476,24 +1476,24 @@ void main() {
   }
 
   function expandStyleURL(url, token) {
-    var prefix = /^mapbox:\/\/styles\//;
+    const prefix = /^mapbox:\/\/styles\//;
     if ( !url.match(prefix) ) return url;
-    var apiRoot = "https://api.mapbox.com/styles/v1/";
+    const apiRoot = "https://api.mapbox.com/styles/v1/";
     return url.replace(prefix, apiRoot) + "?access_token=" + token;
   }
 
   function expandSpriteURLs(url, token) {
     // Returns an array containing urls to .png and .json files
-    var prefix = /^mapbox:\/\/sprites\//;
+    const prefix = /^mapbox:\/\/sprites\//;
     if ( !url.match(prefix) ) return {
       image: url + ".png", 
       meta: url + ".json",
     };
 
     // We have a Mapbox custom url. Expand to an absolute URL, as per the spec
-    var apiRoot = "https://api.mapbox.com/styles/v1/";
+    const apiRoot = "https://api.mapbox.com/styles/v1/";
     url = url.replace(prefix, apiRoot) + "/sprite";
-    var tokenString = "?access_token=" + token;
+    const tokenString = "?access_token=" + token;
     return {
       image: url + ".png" + tokenString, 
       meta: url + ".json" + tokenString,
@@ -1501,50 +1501,57 @@ void main() {
   }
 
   function expandTileURL(url, token) {
-    var prefix = /^mapbox:\/\//;
+    const prefix = /^mapbox:\/\//;
     if ( !url.match(prefix) ) return url;
-    var apiRoot = "https://api.mapbox.com/v4/";
+    const apiRoot = "https://api.mapbox.com/v4/";
     return url.replace(prefix, apiRoot) + ".json?secure&access_token=" + token;
   }
 
   function expandGlyphURL(url, token) {
-    var prefix = /^mapbox:\/\/fonts\//;
+    const prefix = /^mapbox:\/\/fonts\//;
     if ( !url.match(prefix) ) return url;
-    var apiRoot = "https://api.mapbox.com/fonts/v1/";
+    const apiRoot = "https://api.mapbox.com/fonts/v1/";
     return url.replace(prefix, apiRoot) + "?access_token=" + token;
   }
 
-  function getJSON(data) {
-    switch (typeof data) {
-      case "object":
-        // data may be GeoJSON already. Confirm and return
-        return (data !== null && data.type)
-          ? Promise.resolve(data)
-          : Promise.reject(data);
+  function getGeoJSON(data) {
+    const dataPromise = (typeof data === "object" && data !== null)
+      ? Promise.resolve(data)
+      : getJSON(data); // data may be a URL. Try loading it
 
-      case "string":
-        // data must be a URL
-        return fetch(data).then(response => {
-          return (response.ok)
-            ? response.json()
-            : Promise.reject(response);
-        });
+    return dataPromise.then(json => {
+      // Is it valid GeoJSON? For now, just check for a .type property
+      return (json.type)
+        ? json
+        : Promise.reject(Error("invalid GeoJSON: " + JSON.stringify(json)));
+    });
+  }
 
-      default:
-        return Promise.reject(data);
+  function getJSON(href) {
+    return (typeof href === "string" && href.length)
+      ? fetch(href).then(checkFetch)
+      : Promise.reject(Error("invalid URL: " + JSON.stringify(href)));
+  }
+
+  function checkFetch(response) {
+    if (!response.ok) {
+      const { status, statusText, url } = response;
+      const message = ["HTTP", status, statusText, "for URL", url].join(" ");
+      return Promise.reject(Error(message));
     }
+
+    return response.json();
   }
 
   function getImage(href) {
-    const errMsg = "ERROR in getImage for href " + href;
     const img = new Image();
 
     return new Promise( (resolve, reject) => {
-      img.onerror = () => reject(errMsg);
+      img.onerror = () => reject(Error("Failed to retrieve image from " + href));
 
       img.onload = () => (img.complete && img.naturalWidth !== 0)
           ? resolve(img)
-          : reject(errMsg);
+          : reject(Error("Incomplete image received from " + href));
 
       img.crossOrigin = "anonymous";
       img.src = href;
@@ -2275,18 +2282,18 @@ void main() {
   }
 
   function loadLinks(styleDoc, mapboxToken) {
-    styleDoc.layers = derefLayers(styleDoc.layers);
-    if (styleDoc.glyphs) {
-      styleDoc.glyphs = expandGlyphURL(styleDoc.glyphs, mapboxToken);
+    const { sources: rawSources, glyphs, sprite, layers } = styleDoc;
+
+    styleDoc.layers = derefLayers(layers);
+    if (glyphs) {
+      styleDoc.glyphs = expandGlyphURL(glyphs, mapboxToken);
     }
 
     return Promise.all([
-      expandSources(styleDoc.sources, mapboxToken),
-      loadSprite(styleDoc.sprite, mapboxToken),
-    ]).then( ([sources, spriteData]) => {
-      styleDoc.sources = sources;
-      styleDoc.spriteData = spriteData;
-      return styleDoc;
+      expandSources(rawSources, mapboxToken),
+      loadSprite(sprite, mapboxToken),
+    ]).then(([sources, spriteData]) => {
+      return Object.assign(styleDoc, { sources, spriteData });
     });
   }
 
@@ -2294,30 +2301,34 @@ void main() {
     const expandPromises = Object.entries(rawSources).map(expandSource);
 
     function expandSource([key, source]) {
-      if (source.type === "geojson") {
-        return getJSON(source.data).then(JSON => {
-          source.data = JSON;
-          return [key, source];
-        });
+      const { type, url } = source;
+
+      const infoPromise =
+        (type === "geojson") ? getGeoJSON(source.data).then(data => ({ data }))
+        : (url) ? getJSON(expandTileURL(url, token)) // Get linked TileJSON
+        : Promise.resolve({}); // No linked info
+
+      return infoPromise.then(info => {
+        // Assign everything to a new object for return.
+        // Note: shallow copy! Some properties may point back to the original
+        // style document, like .vector_layers, .bounds, .center, .extent
+        const updatedSource = Object.assign({}, source, info, { type });
+        return { [key]: updatedSource };
+      });
+    }
+
+    return Promise.allSettled(expandPromises)
+      .then(results => results.reduce(processResult, {}));
+
+    function processResult(sources, result) {
+      if (result.status === "fulfilled") {
+        return Object.assign(sources, result.value);
+      } else {
+        // If one source fails to load, just log the reason and move on
+        warn("Error loading sources: " + result.reason.message);
+        return sources;
       }
-
-      // If no .url, return a shallow copy of the input. 
-      // Note: some properties may still be pointing back to the original 
-      // style document, like .vector_layers, .bounds, .center, .extent
-      if (source.url === undefined) return [key, Object.assign({}, source)];
-
-      // Load the referenced TileJSON document, add any values from source
-      return getJSON( expandTileURL(source.url, token) )
-        .then( tileJson => [key, Object.assign(tileJson, source)] );
     }
-
-    function combineSources(keySourcePairs) {
-      const sources = {};
-      keySourcePairs.forEach( ([key, val]) => { sources[key] = val; } );
-      return sources;
-    }
-
-    return Promise.all( expandPromises ).then( combineSources );
   }
 
   function loadSprite(sprite, token) {
@@ -2326,7 +2337,17 @@ void main() {
     const urls = expandSpriteURLs(sprite, token);
 
     return Promise.all([getImage(urls.image), getJSON(urls.meta)])
-      .then( ([image, meta]) => ({ image, meta }) );
+      .then( ([image, meta]) => ({ image, meta }) )
+      .catch(err => {
+        // If sprite doesn't load, just log the error and move on
+        warn("Error loading sprite: " + err.message);
+      });
+  }
+
+  function warn(message) {
+    console.log("tile-stencil had a problem loading part of the style document");
+    console.log("  " + message);
+    console.log("  Not a fatal error. Proceeding with the rest of the style...");
   }
 
   function getStyleFuncs(inputLayer) {
@@ -2346,13 +2367,28 @@ void main() {
       ? Promise.resolve(style)                // style is JSON already
       : getJSON( expandStyleURL(style, mapboxToken) ); // Get from URL
 
-    return getStyle
+    return getStyle.then(checkStyle)
       .then( styleDoc => loadLinks(styleDoc, mapboxToken) );
   }
 
-  initZeroTimeouts();
+  function checkStyle(doc) {
+    const { version, sources, layers } = doc;
 
-  function initZeroTimeouts() {
+    const error =
+      (typeof sources !== "object" || sources === null || Array.isArray(sources))
+      ? "missing sources object"
+      : (!Array.isArray(layers))
+      ? "missing layers array"
+      : (version !== 8)
+      ? "unsupported version number"
+      : null;
+
+    return (error) ? Promise.reject(error) : doc;
+  }
+
+  initZeroTimeouts$1();
+
+  function initZeroTimeouts$1() {
     // setTimeout with true zero delay. https://github.com/GlobeletJS/zero-timeout
     const timeouts = [];
     var taskId = 0;
@@ -2447,9 +2483,9 @@ void main() {
     }
   }
 
-  initZeroTimeouts$1();
+  initZeroTimeouts();
 
-  function initZeroTimeouts$1() {
+  function initZeroTimeouts() {
     // setTimeout with true zero delay. https://github.com/GlobeletJS/zero-timeout
     const timeouts = [];
     var taskId = 0;
@@ -2546,7 +2582,7 @@ void main() {
 
   const vectorTypes = ["symbol", "circle", "line", "fill"];
 
-  function setParams$1$1(userParams) {
+  function setParams$2(userParams) {
     const {
       threads = 2,
       context,
@@ -2558,18 +2594,18 @@ void main() {
     } = userParams;
 
     // Confirm supplied styles are all vector layers reading from the same source
-    if (!layers || !layers.length) fail$1("no valid array of style layers!");
+    if (!layers || !layers.length) fail("no valid array of style layers!");
 
     let allVectors = layers.every( l => vectorTypes.includes(l.type) );
-    if (!allVectors) fail$1("not all layers are vector types!");
+    if (!allVectors) fail("not all layers are vector types!");
 
     let sameSource = layers.every( l => l.source === layers[0].source );
-    if (!sameSource) fail$1("supplied layers use different sources!");
+    if (!sameSource) fail("supplied layers use different sources!");
 
-    if (!source) fail$1("parameters.source is required!");
+    if (!source) fail("parameters.source is required!");
 
     if (source.type === "vector" && !(source.tiles && source.tiles.length)) {
-      fail$1("no valid vector tile endpoints!");
+      fail("no valid vector tile endpoints!");
     }
 
     return {
@@ -2583,7 +2619,7 @@ void main() {
     };
   }
 
-  function fail$1(message) {
+  function fail(message) {
     throw Error("ERROR in tile-mixer: " + message);
   }
 
@@ -2668,7 +2704,7 @@ void main() {
   prototype.constructor = constructor;
 }
 
-function extend(parent, definition) {
+function extend$2(parent, definition) {
   var prototype = Object.create(parent.prototype);
   for (var key in definition) prototype[key] = definition[key];
   return prototype;
@@ -2913,7 +2949,7 @@ function Rgb(r, g, b, opacity) {
   this.opacity = +opacity;
 }
 
-define(Rgb, rgb, extend(Color, {
+define(Rgb, rgb, extend$2(Color, {
   brighter: function(k) {
     k = k == null ? brighter : Math.pow(brighter, k);
     return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
@@ -2999,7 +3035,7 @@ function Hsl(h, s, l, opacity) {
   this.opacity = +opacity;
 }
 
-define(Hsl, hsl, extend(Color, {
+define(Hsl, hsl, extend$2(Color, {
   brighter: function(k) {
     k = k == null ? brighter : Math.pow(brighter, k);
     return new Hsl(this.h, this.s, this.l * k, this.opacity);
@@ -3333,19 +3369,9 @@ const paintDefaults = {
   },
 };
 
-function getStyleFuncs(inputLayer) {
-  const layer = Object.assign({}, inputLayer); // Leave input unchanged
-
-  // Replace rendering properties with functions
-  layer.layout = autoGetters(layer.layout, layoutDefaults[layer.type]);
-  layer.paint  = autoGetters(layer.paint,  paintDefaults[layer.type] );
-
-  return layer;
-}
-
 function buildFeatureFilter(filterObj) {
   // filterObj is a filter definition following the "deprecated" syntax:
-  // https://docs.mapbox.com/mapbox-gl-js/style-spec/#other-filter
+  // https://maplibre.org/maplibre-gl-js-docs/style-spec/other/#other-filter
   if (!filterObj) return () => true;
   const [type, ...vals] = filterObj;
 
@@ -3423,6 +3449,16 @@ function initFeatureValGetter(key) {
   }
 }
 
+function getStyleFuncs(inputLayer) {
+  const layer = Object.assign({}, inputLayer); // Leave input unchanged
+
+  // Replace rendering properties with functions
+  layer.layout = autoGetters(layer.layout, layoutDefaults[layer.type]);
+  layer.paint  = autoGetters(layer.paint,  paintDefaults[layer.type] );
+
+  return layer;
+}
+
 function initSourceFilter(styles) {
   const filters = styles.map(initLayerFilter);
 
@@ -3474,8 +3510,11 @@ function getGeomFilter(type) {
   }
 }
 
+var ieee754$1 = {};
+
 /*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> */
-var read = function (buffer, offset, isLE, mLen, nBytes) {
+
+ieee754$1.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m;
   var eLen = (nBytes * 8) - mLen - 1;
   var eMax = (1 << eLen) - 1;
@@ -3508,7 +3547,7 @@ var read = function (buffer, offset, isLE, mLen, nBytes) {
   return (s ? -1 : 1) * m * Math.pow(2, e - mLen)
 };
 
-var write = function (buffer, value, offset, isLE, mLen, nBytes) {
+ieee754$1.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   var e, m, c;
   var eLen = (nBytes * 8) - mLen - 1;
   var eMax = (1 << eLen) - 1;
@@ -3560,14 +3599,9 @@ var write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128;
 };
 
-var ieee754 = {
-	read: read,
-	write: write
-};
-
 var pbf = Pbf;
 
-
+var ieee754 = ieee754$1;
 
 function Pbf(buf) {
     this.buf = ArrayBuffer.isView && ArrayBuffer.isView(buf) ? buf : new Uint8Array(buf || 0);
@@ -4291,7 +4325,7 @@ function outOfRange(point, size, image) {
   );
 }
 
-const GLYPH_PBF_BORDER = 3;
+const GLYPH_PBF_BORDER$1 = 3;
 
 function parseGlyphPbf(data) {
   // See mapbox-gl-js/src/style/parse_glyph_pbf.js
@@ -4309,7 +4343,7 @@ function readFontstack(tag, glyphs, pbf) {
   const glyph = pbf.readMessage(readGlyph, {});
   const { id, bitmap, width, height, left, top, advance } = glyph;
 
-  const borders = 2 * GLYPH_PBF_BORDER;
+  const borders = 2 * GLYPH_PBF_BORDER$1;
   const size = { width: width + borders, height: height + borders };
 
   glyphs.push({
@@ -4459,7 +4493,7 @@ function potpack(boxes) {
     };
 }
 
-const ATLAS_PADDING = 1;
+const ATLAS_PADDING$1 = 1;
 
 function buildAtlas(fonts) {
   // See mapbox-gl-js/src/render/glyph_atlas.js
@@ -4501,8 +4535,8 @@ function getPosition(glyph) {
   if (width === 0 || height === 0) return;
 
   // Construct a preliminary rect, positioned at the origin for now
-  let w = width + 2 * ATLAS_PADDING;
-  let h = height + 2 * ATLAS_PADDING;
+  let w = width + 2 * ATLAS_PADDING$1;
+  let h = height + 2 * ATLAS_PADDING$1;
   let rect = { x: 0, y: 0, w, h };
 
   return { metrics, rect };
@@ -4515,7 +4549,7 @@ function copyGlyphBitmap(glyph, positions, image) {
 
   let srcPt = { x: 0, y: 0 };
   let { x, y } = position.rect;
-  let dstPt = { x: x + ATLAS_PADDING, y: y + ATLAS_PADDING };
+  let dstPt = { x: x + ATLAS_PADDING$1, y: y + ATLAS_PADDING$1 };
   AlphaImage.copy(bitmap, image, srcPt, dstPt, bitmap);
 }
 
@@ -4761,8 +4795,10 @@ function flattenLinearRing(ring) {
   ];
 }
 
-var earcut_1 = earcut;
-var default_1 = earcut;
+var earcut$2 = {exports: {}};
+
+earcut$2.exports = earcut;
+earcut$2.exports.default = earcut;
 
 function earcut(data, holeIndices, dim) {
 
@@ -4807,7 +4843,7 @@ function earcut(data, holeIndices, dim) {
 function linkedList(data, start, end, dim, clockwise) {
     var i, last;
 
-    if (clockwise === (signedArea(data, start, end, dim) > 0)) {
+    if (clockwise === (signedArea$1(data, start, end, dim) > 0)) {
         for (i = start; i < end; i += dim) last = insertNode(i, data[i], data[i + 1], last);
     } else {
         for (i = end - dim; i >= start; i -= dim) last = insertNode(i, data[i], data[i + 1], last);
@@ -4977,7 +5013,7 @@ function cureLocalIntersections(start, triangles, dim) {
         var a = p.prev,
             b = p.next.next;
 
-        if (!equals(a, b) && intersects(a, p, p.next, b) && locallyInside(a, b) && locallyInside(b, a)) {
+        if (!equals(a, b) && intersects$1(a, p, p.next, b) && locallyInside(a, b) && locallyInside(b, a)) {
 
             triangles.push(a.i / dim);
             triangles.push(p.i / dim);
@@ -5252,7 +5288,7 @@ function equals(p1, p2) {
 }
 
 // check if two segments intersect
-function intersects(p1, q1, p2, q2) {
+function intersects$1(p1, q1, p2, q2) {
     var o1 = sign(area(p1, q1, p2));
     var o2 = sign(area(p1, q1, q2));
     var o3 = sign(area(p2, q2, p1));
@@ -5282,7 +5318,7 @@ function intersectsPolygon(a, b) {
     var p = a;
     do {
         if (p.i !== a.i && p.next.i !== a.i && p.i !== b.i && p.next.i !== b.i &&
-                intersects(p, p.next, a, b)) return true;
+                intersects$1(p, p.next, a, b)) return true;
         p = p.next;
     } while (p !== a);
 
@@ -5389,12 +5425,12 @@ earcut.deviation = function (data, holeIndices, dim, triangles) {
     var hasHoles = holeIndices && holeIndices.length;
     var outerLen = hasHoles ? holeIndices[0] * dim : data.length;
 
-    var polygonArea = Math.abs(signedArea(data, 0, outerLen, dim));
+    var polygonArea = Math.abs(signedArea$1(data, 0, outerLen, dim));
     if (hasHoles) {
         for (var i = 0, len = holeIndices.length; i < len; i++) {
             var start = holeIndices[i] * dim;
             var end = i < len - 1 ? holeIndices[i + 1] * dim : data.length;
-            polygonArea -= Math.abs(signedArea(data, start, end, dim));
+            polygonArea -= Math.abs(signedArea$1(data, start, end, dim));
         }
     }
 
@@ -5412,7 +5448,7 @@ earcut.deviation = function (data, holeIndices, dim, triangles) {
         Math.abs((trianglesArea - polygonArea) / polygonArea);
 };
 
-function signedArea(data, start, end, dim) {
+function signedArea$1(data, start, end, dim) {
     var sum = 0;
     for (var i = start, j = end - dim; i < end; i += dim) {
         sum += (data[j] - data[i]) * (data[i + 1] + data[j + 1]);
@@ -5438,7 +5474,8 @@ earcut.flatten = function (data) {
     }
     return result;
 };
-earcut_1.default = default_1;
+
+var earcut$1 = earcut$2.exports;
 
 function initFillParsing(style) {
   const { paint } = style;
@@ -5488,17 +5525,17 @@ function triangulate(geometry) {
 }
 
 function indexPolygon(coords) {
-  let { vertices, holes, dimensions } = earcut_1.flatten(coords);
-  let indices = earcut_1(vertices, holes, dimensions);
+  let { vertices, holes, dimensions } = earcut$1.flatten(coords);
+  let indices = earcut$1(vertices, holes, dimensions);
   return { vertices, indices };
 }
 
-const GLYPH_PBF_BORDER$1 = 3;
+const GLYPH_PBF_BORDER = 3;
 const ONE_EM = 24;
 
-const ATLAS_PADDING$1 = 1;
+const ATLAS_PADDING = 1;
 
-const RECT_BUFFER = GLYPH_PBF_BORDER$1 + ATLAS_PADDING$1;
+const RECT_BUFFER = GLYPH_PBF_BORDER + ATLAS_PADDING;
 
 function layoutLine(glyphs, origin, spacing, scalar) {
   var xCursor = origin[0];
@@ -5952,7 +5989,7 @@ class RBush {
         let node = this.data;
         const result = [];
 
-        if (!intersects$1(bbox, node)) return result;
+        if (!intersects(bbox, node)) return result;
 
         const toBBox = this.toBBox;
         const nodesToSearch = [];
@@ -5962,7 +5999,7 @@ class RBush {
                 const child = node.children[i];
                 const childBBox = node.leaf ? toBBox(child) : child;
 
-                if (intersects$1(bbox, childBBox)) {
+                if (intersects(bbox, childBBox)) {
                     if (node.leaf) result.push(child);
                     else if (contains(bbox, childBBox)) this._all(child, result);
                     else nodesToSearch.push(child);
@@ -5977,7 +6014,7 @@ class RBush {
     collides(bbox) {
         let node = this.data;
 
-        if (!intersects$1(bbox, node)) return false;
+        if (!intersects(bbox, node)) return false;
 
         const nodesToSearch = [];
         while (node) {
@@ -5985,7 +6022,7 @@ class RBush {
                 const child = node.children[i];
                 const childBBox = node.leaf ? this.toBBox(child) : child;
 
-                if (intersects$1(bbox, childBBox)) {
+                if (intersects(bbox, childBBox)) {
                     if (node.leaf || contains(bbox, childBBox)) return true;
                     nodesToSearch.push(child);
                 }
@@ -6123,7 +6160,7 @@ class RBush {
         if (N <= M) {
             // reached leaf level; return leaf
             node = createNode(items.slice(left, right + 1));
-            calcBBox(node, this.toBBox);
+            calcBBox$1(node, this.toBBox);
             return node;
         }
 
@@ -6161,7 +6198,7 @@ class RBush {
             }
         }
 
-        calcBBox(node, this.toBBox);
+        calcBBox$1(node, this.toBBox);
 
         return node;
     }
@@ -6239,8 +6276,8 @@ class RBush {
         newNode.height = node.height;
         newNode.leaf = node.leaf;
 
-        calcBBox(node, this.toBBox);
-        calcBBox(newNode, this.toBBox);
+        calcBBox$1(node, this.toBBox);
+        calcBBox$1(newNode, this.toBBox);
 
         if (level) insertPath[level - 1].children.push(newNode);
         else this._splitRoot(node, newNode);
@@ -6251,7 +6288,7 @@ class RBush {
         this.data = createNode([node, newNode]);
         this.data.height = node.height + 1;
         this.data.leaf = false;
-        calcBBox(this.data, this.toBBox);
+        calcBBox$1(this.data, this.toBBox);
     }
 
     _chooseSplitIndex(node, m, M) {
@@ -6338,7 +6375,7 @@ class RBush {
 
                 } else this.clear();
 
-            } else calcBBox(path[i], this.toBBox);
+            } else calcBBox$1(path[i], this.toBBox);
         }
     }
 }
@@ -6353,7 +6390,7 @@ function findItem(item, items, equalsFn) {
 }
 
 // calculate node's bbox from bboxes of its children
-function calcBBox(node, toBBox) {
+function calcBBox$1(node, toBBox) {
     distBBox(node, 0, node.children.length, toBBox, node);
 }
 
@@ -6409,7 +6446,7 @@ function contains(a, b) {
            b.maxY <= a.maxY;
 }
 
-function intersects$1(a, b) {
+function intersects(a, b) {
     return b.minX <= a.maxX &&
            b.minY <= a.maxY &&
            b.maxX >= a.minX &&
@@ -6521,7 +6558,7 @@ function classifyRings(rings) {
   var polygon, ccw;
 
   rings.forEach(ring => {
-    let area = signedArea$1(ring);
+    let area = signedArea(ring);
     if (area === 0) return;
 
     if (ccw === undefined) ccw = area < 0;
@@ -6539,7 +6576,7 @@ function classifyRings(rings) {
   return polygons;
 }
 
-function signedArea$1(ring) {
+function signedArea(ring) {
   const xmul = (p1, p2) => (p2.x - p1.x) * (p1.y + p2.y);
 
   const initialValue = xmul(ring[0], ring[ring.length - 1]);
@@ -6935,11 +6972,11 @@ function createFeature(id, type, geom, tags) {
         maxX: -Infinity,
         maxY: -Infinity
     };
-    calcBBox$1(feature);
+    calcBBox(feature);
     return feature;
 }
 
-function calcBBox$1(feature) {
+function calcBBox(feature) {
     var geom = feature.geometry;
     var type = feature.type;
 
@@ -7555,7 +7592,7 @@ function geojsonvt(data, options) {
 }
 
 function GeoJSONVT(data, options) {
-    options = this.options = extend$2(Object.create(this.options), options);
+    options = this.options = extend(Object.create(this.options), options);
 
     var debug = options.debug;
 
@@ -7739,7 +7776,7 @@ function toID(z, x, y) {
     return (((1 << z) * y + x) * 32) + z;
 }
 
-function extend$2(dest, src) {
+function extend(dest, src) {
     for (var i in src) dest[i] = src[i];
     return dest;
 }
@@ -7848,7 +7885,7 @@ function sendTile(id, tile) {
 `;
 
   function initTileMixer(userParams) {
-    const params = setParams$1$1(userParams);
+    const params = setParams$2(userParams);
     const { queue, context: { loadBuffers, loadAtlas } } = params;
 
     // Initialize workers
@@ -8365,790 +8402,6 @@ function sendTile(id, tile) {
     }
   }
 
-  function unwrapExports (x) {
-  	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-  }
-
-  function createCommonjsModule(fn, module) {
-  	return module = { exports: {} }, fn(module, module.exports), module.exports;
-  }
-
-  var helpers = createCommonjsModule(function (module, exports) {
-  Object.defineProperty(exports, "__esModule", { value: true });
-  /**
-   * @module helpers
-   */
-  /**
-   * Earth Radius used with the Harvesine formula and approximates using a spherical (non-ellipsoid) Earth.
-   *
-   * @memberof helpers
-   * @type {number}
-   */
-  exports.earthRadius = 6371008.8;
-  /**
-   * Unit of measurement factors using a spherical (non-ellipsoid) earth radius.
-   *
-   * @memberof helpers
-   * @type {Object}
-   */
-  exports.factors = {
-      centimeters: exports.earthRadius * 100,
-      centimetres: exports.earthRadius * 100,
-      degrees: exports.earthRadius / 111325,
-      feet: exports.earthRadius * 3.28084,
-      inches: exports.earthRadius * 39.370,
-      kilometers: exports.earthRadius / 1000,
-      kilometres: exports.earthRadius / 1000,
-      meters: exports.earthRadius,
-      metres: exports.earthRadius,
-      miles: exports.earthRadius / 1609.344,
-      millimeters: exports.earthRadius * 1000,
-      millimetres: exports.earthRadius * 1000,
-      nauticalmiles: exports.earthRadius / 1852,
-      radians: 1,
-      yards: exports.earthRadius / 1.0936,
-  };
-  /**
-   * Units of measurement factors based on 1 meter.
-   *
-   * @memberof helpers
-   * @type {Object}
-   */
-  exports.unitsFactors = {
-      centimeters: 100,
-      centimetres: 100,
-      degrees: 1 / 111325,
-      feet: 3.28084,
-      inches: 39.370,
-      kilometers: 1 / 1000,
-      kilometres: 1 / 1000,
-      meters: 1,
-      metres: 1,
-      miles: 1 / 1609.344,
-      millimeters: 1000,
-      millimetres: 1000,
-      nauticalmiles: 1 / 1852,
-      radians: 1 / exports.earthRadius,
-      yards: 1 / 1.0936,
-  };
-  /**
-   * Area of measurement factors based on 1 square meter.
-   *
-   * @memberof helpers
-   * @type {Object}
-   */
-  exports.areaFactors = {
-      acres: 0.000247105,
-      centimeters: 10000,
-      centimetres: 10000,
-      feet: 10.763910417,
-      inches: 1550.003100006,
-      kilometers: 0.000001,
-      kilometres: 0.000001,
-      meters: 1,
-      metres: 1,
-      miles: 3.86e-7,
-      millimeters: 1000000,
-      millimetres: 1000000,
-      yards: 1.195990046,
-  };
-  /**
-   * Wraps a GeoJSON {@link Geometry} in a GeoJSON {@link Feature}.
-   *
-   * @name feature
-   * @param {Geometry} geometry input geometry
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {Feature} a GeoJSON Feature
-   * @example
-   * var geometry = {
-   *   "type": "Point",
-   *   "coordinates": [110, 50]
-   * };
-   *
-   * var feature = turf.feature(geometry);
-   *
-   * //=feature
-   */
-  function feature(geom, properties, options) {
-      if (options === void 0) { options = {}; }
-      var feat = { type: "Feature" };
-      if (options.id === 0 || options.id) {
-          feat.id = options.id;
-      }
-      if (options.bbox) {
-          feat.bbox = options.bbox;
-      }
-      feat.properties = properties || {};
-      feat.geometry = geom;
-      return feat;
-  }
-  exports.feature = feature;
-  /**
-   * Creates a GeoJSON {@link Geometry} from a Geometry string type & coordinates.
-   * For GeometryCollection type use `helpers.geometryCollection`
-   *
-   * @name geometry
-   * @param {string} type Geometry Type
-   * @param {Array<any>} coordinates Coordinates
-   * @param {Object} [options={}] Optional Parameters
-   * @returns {Geometry} a GeoJSON Geometry
-   * @example
-   * var type = "Point";
-   * var coordinates = [110, 50];
-   * var geometry = turf.geometry(type, coordinates);
-   * // => geometry
-   */
-  function geometry(type, coordinates, options) {
-      switch (type) {
-          case "Point": return point(coordinates).geometry;
-          case "LineString": return lineString(coordinates).geometry;
-          case "Polygon": return polygon(coordinates).geometry;
-          case "MultiPoint": return multiPoint(coordinates).geometry;
-          case "MultiLineString": return multiLineString(coordinates).geometry;
-          case "MultiPolygon": return multiPolygon(coordinates).geometry;
-          default: throw new Error(type + " is invalid");
-      }
-  }
-  exports.geometry = geometry;
-  /**
-   * Creates a {@link Point} {@link Feature} from a Position.
-   *
-   * @name point
-   * @param {Array<number>} coordinates longitude, latitude position (each in decimal degrees)
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {Feature<Point>} a Point feature
-   * @example
-   * var point = turf.point([-75.343, 39.984]);
-   *
-   * //=point
-   */
-  function point(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      var geom = {
-          type: "Point",
-          coordinates: coordinates,
-      };
-      return feature(geom, properties, options);
-  }
-  exports.point = point;
-  /**
-   * Creates a {@link Point} {@link FeatureCollection} from an Array of Point coordinates.
-   *
-   * @name points
-   * @param {Array<Array<number>>} coordinates an array of Points
-   * @param {Object} [properties={}] Translate these properties to each Feature
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north]
-   * associated with the FeatureCollection
-   * @param {string|number} [options.id] Identifier associated with the FeatureCollection
-   * @returns {FeatureCollection<Point>} Point Feature
-   * @example
-   * var points = turf.points([
-   *   [-75, 39],
-   *   [-80, 45],
-   *   [-78, 50]
-   * ]);
-   *
-   * //=points
-   */
-  function points(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      return featureCollection(coordinates.map(function (coords) {
-          return point(coords, properties);
-      }), options);
-  }
-  exports.points = points;
-  /**
-   * Creates a {@link Polygon} {@link Feature} from an Array of LinearRings.
-   *
-   * @name polygon
-   * @param {Array<Array<Array<number>>>} coordinates an array of LinearRings
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {Feature<Polygon>} Polygon Feature
-   * @example
-   * var polygon = turf.polygon([[[-5, 52], [-4, 56], [-2, 51], [-7, 54], [-5, 52]]], { name: 'poly1' });
-   *
-   * //=polygon
-   */
-  function polygon(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      for (var _i = 0, coordinates_1 = coordinates; _i < coordinates_1.length; _i++) {
-          var ring = coordinates_1[_i];
-          if (ring.length < 4) {
-              throw new Error("Each LinearRing of a Polygon must have 4 or more Positions.");
-          }
-          for (var j = 0; j < ring[ring.length - 1].length; j++) {
-              // Check if first point of Polygon contains two numbers
-              if (ring[ring.length - 1][j] !== ring[0][j]) {
-                  throw new Error("First and last Position are not equivalent.");
-              }
-          }
-      }
-      var geom = {
-          type: "Polygon",
-          coordinates: coordinates,
-      };
-      return feature(geom, properties, options);
-  }
-  exports.polygon = polygon;
-  /**
-   * Creates a {@link Polygon} {@link FeatureCollection} from an Array of Polygon coordinates.
-   *
-   * @name polygons
-   * @param {Array<Array<Array<Array<number>>>>} coordinates an array of Polygon coordinates
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the FeatureCollection
-   * @returns {FeatureCollection<Polygon>} Polygon FeatureCollection
-   * @example
-   * var polygons = turf.polygons([
-   *   [[[-5, 52], [-4, 56], [-2, 51], [-7, 54], [-5, 52]]],
-   *   [[[-15, 42], [-14, 46], [-12, 41], [-17, 44], [-15, 42]]],
-   * ]);
-   *
-   * //=polygons
-   */
-  function polygons(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      return featureCollection(coordinates.map(function (coords) {
-          return polygon(coords, properties);
-      }), options);
-  }
-  exports.polygons = polygons;
-  /**
-   * Creates a {@link LineString} {@link Feature} from an Array of Positions.
-   *
-   * @name lineString
-   * @param {Array<Array<number>>} coordinates an array of Positions
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {Feature<LineString>} LineString Feature
-   * @example
-   * var linestring1 = turf.lineString([[-24, 63], [-23, 60], [-25, 65], [-20, 69]], {name: 'line 1'});
-   * var linestring2 = turf.lineString([[-14, 43], [-13, 40], [-15, 45], [-10, 49]], {name: 'line 2'});
-   *
-   * //=linestring1
-   * //=linestring2
-   */
-  function lineString(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      if (coordinates.length < 2) {
-          throw new Error("coordinates must be an array of two or more positions");
-      }
-      var geom = {
-          type: "LineString",
-          coordinates: coordinates,
-      };
-      return feature(geom, properties, options);
-  }
-  exports.lineString = lineString;
-  /**
-   * Creates a {@link LineString} {@link FeatureCollection} from an Array of LineString coordinates.
-   *
-   * @name lineStrings
-   * @param {Array<Array<Array<number>>>} coordinates an array of LinearRings
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north]
-   * associated with the FeatureCollection
-   * @param {string|number} [options.id] Identifier associated with the FeatureCollection
-   * @returns {FeatureCollection<LineString>} LineString FeatureCollection
-   * @example
-   * var linestrings = turf.lineStrings([
-   *   [[-24, 63], [-23, 60], [-25, 65], [-20, 69]],
-   *   [[-14, 43], [-13, 40], [-15, 45], [-10, 49]]
-   * ]);
-   *
-   * //=linestrings
-   */
-  function lineStrings(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      return featureCollection(coordinates.map(function (coords) {
-          return lineString(coords, properties);
-      }), options);
-  }
-  exports.lineStrings = lineStrings;
-  /**
-   * Takes one or more {@link Feature|Features} and creates a {@link FeatureCollection}.
-   *
-   * @name featureCollection
-   * @param {Feature[]} features input features
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {FeatureCollection} FeatureCollection of Features
-   * @example
-   * var locationA = turf.point([-75.343, 39.984], {name: 'Location A'});
-   * var locationB = turf.point([-75.833, 39.284], {name: 'Location B'});
-   * var locationC = turf.point([-75.534, 39.123], {name: 'Location C'});
-   *
-   * var collection = turf.featureCollection([
-   *   locationA,
-   *   locationB,
-   *   locationC
-   * ]);
-   *
-   * //=collection
-   */
-  function featureCollection(features, options) {
-      if (options === void 0) { options = {}; }
-      var fc = { type: "FeatureCollection" };
-      if (options.id) {
-          fc.id = options.id;
-      }
-      if (options.bbox) {
-          fc.bbox = options.bbox;
-      }
-      fc.features = features;
-      return fc;
-  }
-  exports.featureCollection = featureCollection;
-  /**
-   * Creates a {@link Feature<MultiLineString>} based on a
-   * coordinate array. Properties can be added optionally.
-   *
-   * @name multiLineString
-   * @param {Array<Array<Array<number>>>} coordinates an array of LineStrings
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {Feature<MultiLineString>} a MultiLineString feature
-   * @throws {Error} if no coordinates are passed
-   * @example
-   * var multiLine = turf.multiLineString([[[0,0],[10,10]]]);
-   *
-   * //=multiLine
-   */
-  function multiLineString(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      var geom = {
-          type: "MultiLineString",
-          coordinates: coordinates,
-      };
-      return feature(geom, properties, options);
-  }
-  exports.multiLineString = multiLineString;
-  /**
-   * Creates a {@link Feature<MultiPoint>} based on a
-   * coordinate array. Properties can be added optionally.
-   *
-   * @name multiPoint
-   * @param {Array<Array<number>>} coordinates an array of Positions
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {Feature<MultiPoint>} a MultiPoint feature
-   * @throws {Error} if no coordinates are passed
-   * @example
-   * var multiPt = turf.multiPoint([[0,0],[10,10]]);
-   *
-   * //=multiPt
-   */
-  function multiPoint(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      var geom = {
-          type: "MultiPoint",
-          coordinates: coordinates,
-      };
-      return feature(geom, properties, options);
-  }
-  exports.multiPoint = multiPoint;
-  /**
-   * Creates a {@link Feature<MultiPolygon>} based on a
-   * coordinate array. Properties can be added optionally.
-   *
-   * @name multiPolygon
-   * @param {Array<Array<Array<Array<number>>>>} coordinates an array of Polygons
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {Feature<MultiPolygon>} a multipolygon feature
-   * @throws {Error} if no coordinates are passed
-   * @example
-   * var multiPoly = turf.multiPolygon([[[[0,0],[0,10],[10,10],[10,0],[0,0]]]]);
-   *
-   * //=multiPoly
-   *
-   */
-  function multiPolygon(coordinates, properties, options) {
-      if (options === void 0) { options = {}; }
-      var geom = {
-          type: "MultiPolygon",
-          coordinates: coordinates,
-      };
-      return feature(geom, properties, options);
-  }
-  exports.multiPolygon = multiPolygon;
-  /**
-   * Creates a {@link Feature<GeometryCollection>} based on a
-   * coordinate array. Properties can be added optionally.
-   *
-   * @name geometryCollection
-   * @param {Array<Geometry>} geometries an array of GeoJSON Geometries
-   * @param {Object} [properties={}] an Object of key-value pairs to add as properties
-   * @param {Object} [options={}] Optional Parameters
-   * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
-   * @param {string|number} [options.id] Identifier associated with the Feature
-   * @returns {Feature<GeometryCollection>} a GeoJSON GeometryCollection Feature
-   * @example
-   * var pt = turf.geometry("Point", [100, 0]);
-   * var line = turf.geometry("LineString", [[101, 0], [102, 1]]);
-   * var collection = turf.geometryCollection([pt, line]);
-   *
-   * // => collection
-   */
-  function geometryCollection(geometries, properties, options) {
-      if (options === void 0) { options = {}; }
-      var geom = {
-          type: "GeometryCollection",
-          geometries: geometries,
-      };
-      return feature(geom, properties, options);
-  }
-  exports.geometryCollection = geometryCollection;
-  /**
-   * Round number to precision
-   *
-   * @param {number} num Number
-   * @param {number} [precision=0] Precision
-   * @returns {number} rounded number
-   * @example
-   * turf.round(120.4321)
-   * //=120
-   *
-   * turf.round(120.4321, 2)
-   * //=120.43
-   */
-  function round(num, precision) {
-      if (precision === void 0) { precision = 0; }
-      if (precision && !(precision >= 0)) {
-          throw new Error("precision must be a positive number");
-      }
-      var multiplier = Math.pow(10, precision || 0);
-      return Math.round(num * multiplier) / multiplier;
-  }
-  exports.round = round;
-  /**
-   * Convert a distance measurement (assuming a spherical Earth) from radians to a more friendly unit.
-   * Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, centimeters, feet
-   *
-   * @name radiansToLength
-   * @param {number} radians in radians across the sphere
-   * @param {string} [units="kilometers"] can be degrees, radians, miles, or kilometers inches, yards, metres,
-   * meters, kilometres, kilometers.
-   * @returns {number} distance
-   */
-  function radiansToLength(radians, units) {
-      if (units === void 0) { units = "kilometers"; }
-      var factor = exports.factors[units];
-      if (!factor) {
-          throw new Error(units + " units is invalid");
-      }
-      return radians * factor;
-  }
-  exports.radiansToLength = radiansToLength;
-  /**
-   * Convert a distance measurement (assuming a spherical Earth) from a real-world unit into radians
-   * Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, centimeters, feet
-   *
-   * @name lengthToRadians
-   * @param {number} distance in real units
-   * @param {string} [units="kilometers"] can be degrees, radians, miles, or kilometers inches, yards, metres,
-   * meters, kilometres, kilometers.
-   * @returns {number} radians
-   */
-  function lengthToRadians(distance, units) {
-      if (units === void 0) { units = "kilometers"; }
-      var factor = exports.factors[units];
-      if (!factor) {
-          throw new Error(units + " units is invalid");
-      }
-      return distance / factor;
-  }
-  exports.lengthToRadians = lengthToRadians;
-  /**
-   * Convert a distance measurement (assuming a spherical Earth) from a real-world unit into degrees
-   * Valid units: miles, nauticalmiles, inches, yards, meters, metres, centimeters, kilometres, feet
-   *
-   * @name lengthToDegrees
-   * @param {number} distance in real units
-   * @param {string} [units="kilometers"] can be degrees, radians, miles, or kilometers inches, yards, metres,
-   * meters, kilometres, kilometers.
-   * @returns {number} degrees
-   */
-  function lengthToDegrees(distance, units) {
-      return radiansToDegrees(lengthToRadians(distance, units));
-  }
-  exports.lengthToDegrees = lengthToDegrees;
-  /**
-   * Converts any bearing angle from the north line direction (positive clockwise)
-   * and returns an angle between 0-360 degrees (positive clockwise), 0 being the north line
-   *
-   * @name bearingToAzimuth
-   * @param {number} bearing angle, between -180 and +180 degrees
-   * @returns {number} angle between 0 and 360 degrees
-   */
-  function bearingToAzimuth(bearing) {
-      var angle = bearing % 360;
-      if (angle < 0) {
-          angle += 360;
-      }
-      return angle;
-  }
-  exports.bearingToAzimuth = bearingToAzimuth;
-  /**
-   * Converts an angle in radians to degrees
-   *
-   * @name radiansToDegrees
-   * @param {number} radians angle in radians
-   * @returns {number} degrees between 0 and 360 degrees
-   */
-  function radiansToDegrees(radians) {
-      var degrees = radians % (2 * Math.PI);
-      return degrees * 180 / Math.PI;
-  }
-  exports.radiansToDegrees = radiansToDegrees;
-  /**
-   * Converts an angle in degrees to radians
-   *
-   * @name degreesToRadians
-   * @param {number} degrees angle between 0 and 360 degrees
-   * @returns {number} angle in radians
-   */
-  function degreesToRadians(degrees) {
-      var radians = degrees % 360;
-      return radians * Math.PI / 180;
-  }
-  exports.degreesToRadians = degreesToRadians;
-  /**
-   * Converts a length to the requested unit.
-   * Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, centimeters, feet
-   *
-   * @param {number} length to be converted
-   * @param {Units} [originalUnit="kilometers"] of the length
-   * @param {Units} [finalUnit="kilometers"] returned unit
-   * @returns {number} the converted length
-   */
-  function convertLength(length, originalUnit, finalUnit) {
-      if (originalUnit === void 0) { originalUnit = "kilometers"; }
-      if (finalUnit === void 0) { finalUnit = "kilometers"; }
-      if (!(length >= 0)) {
-          throw new Error("length must be a positive number");
-      }
-      return radiansToLength(lengthToRadians(length, originalUnit), finalUnit);
-  }
-  exports.convertLength = convertLength;
-  /**
-   * Converts a area to the requested unit.
-   * Valid units: kilometers, kilometres, meters, metres, centimetres, millimeters, acres, miles, yards, feet, inches
-   * @param {number} area to be converted
-   * @param {Units} [originalUnit="meters"] of the distance
-   * @param {Units} [finalUnit="kilometers"] returned unit
-   * @returns {number} the converted distance
-   */
-  function convertArea(area, originalUnit, finalUnit) {
-      if (originalUnit === void 0) { originalUnit = "meters"; }
-      if (finalUnit === void 0) { finalUnit = "kilometers"; }
-      if (!(area >= 0)) {
-          throw new Error("area must be a positive number");
-      }
-      var startFactor = exports.areaFactors[originalUnit];
-      if (!startFactor) {
-          throw new Error("invalid original units");
-      }
-      var finalFactor = exports.areaFactors[finalUnit];
-      if (!finalFactor) {
-          throw new Error("invalid final units");
-      }
-      return (area / startFactor) * finalFactor;
-  }
-  exports.convertArea = convertArea;
-  /**
-   * isNumber
-   *
-   * @param {*} num Number to validate
-   * @returns {boolean} true/false
-   * @example
-   * turf.isNumber(123)
-   * //=true
-   * turf.isNumber('foo')
-   * //=false
-   */
-  function isNumber(num) {
-      return !isNaN(num) && num !== null && !Array.isArray(num) && !/^\s*$/.test(num);
-  }
-  exports.isNumber = isNumber;
-  /**
-   * isObject
-   *
-   * @param {*} input variable to validate
-   * @returns {boolean} true/false
-   * @example
-   * turf.isObject({elevation: 10})
-   * //=true
-   * turf.isObject('foo')
-   * //=false
-   */
-  function isObject(input) {
-      return (!!input) && (input.constructor === Object);
-  }
-  exports.isObject = isObject;
-  /**
-   * Validate BBox
-   *
-   * @private
-   * @param {Array<number>} bbox BBox to validate
-   * @returns {void}
-   * @throws Error if BBox is not valid
-   * @example
-   * validateBBox([-180, -40, 110, 50])
-   * //=OK
-   * validateBBox([-180, -40])
-   * //=Error
-   * validateBBox('Foo')
-   * //=Error
-   * validateBBox(5)
-   * //=Error
-   * validateBBox(null)
-   * //=Error
-   * validateBBox(undefined)
-   * //=Error
-   */
-  function validateBBox(bbox) {
-      if (!bbox) {
-          throw new Error("bbox is required");
-      }
-      if (!Array.isArray(bbox)) {
-          throw new Error("bbox must be an Array");
-      }
-      if (bbox.length !== 4 && bbox.length !== 6) {
-          throw new Error("bbox must be an Array of 4 or 6 numbers");
-      }
-      bbox.forEach(function (num) {
-          if (!isNumber(num)) {
-              throw new Error("bbox must only contain numbers");
-          }
-      });
-  }
-  exports.validateBBox = validateBBox;
-  /**
-   * Validate Id
-   *
-   * @private
-   * @param {string|number} id Id to validate
-   * @returns {void}
-   * @throws Error if Id is not valid
-   * @example
-   * validateId([-180, -40, 110, 50])
-   * //=Error
-   * validateId([-180, -40])
-   * //=Error
-   * validateId('Foo')
-   * //=OK
-   * validateId(5)
-   * //=OK
-   * validateId(null)
-   * //=Error
-   * validateId(undefined)
-   * //=Error
-   */
-  function validateId(id) {
-      if (!id) {
-          throw new Error("id is required");
-      }
-      if (["string", "number"].indexOf(typeof id) === -1) {
-          throw new Error("id must be a number or a string");
-      }
-  }
-  exports.validateId = validateId;
-  // Deprecated methods
-  function radians2degrees() {
-      throw new Error("method has been renamed to `radiansToDegrees`");
-  }
-  exports.radians2degrees = radians2degrees;
-  function degrees2radians() {
-      throw new Error("method has been renamed to `degreesToRadians`");
-  }
-  exports.degrees2radians = degrees2radians;
-  function distanceToDegrees() {
-      throw new Error("method has been renamed to `lengthToDegrees`");
-  }
-  exports.distanceToDegrees = distanceToDegrees;
-  function distanceToRadians() {
-      throw new Error("method has been renamed to `lengthToRadians`");
-  }
-  exports.distanceToRadians = distanceToRadians;
-  function radiansToDistance() {
-      throw new Error("method has been renamed to `radiansToLength`");
-  }
-  exports.radiansToDistance = radiansToDistance;
-  function bearingToAngle() {
-      throw new Error("method has been renamed to `bearingToAzimuth`");
-  }
-  exports.bearingToAngle = bearingToAngle;
-  function convertDistance() {
-      throw new Error("method has been renamed to `convertLength`");
-  }
-  exports.convertDistance = convertDistance;
-  });
-
-  unwrapExports(helpers);
-  helpers.earthRadius;
-  helpers.factors;
-  helpers.unitsFactors;
-  helpers.areaFactors;
-  helpers.feature;
-  helpers.geometry;
-  helpers.point;
-  helpers.points;
-  helpers.polygon;
-  helpers.polygons;
-  helpers.lineString;
-  helpers.lineStrings;
-  helpers.featureCollection;
-  helpers.multiLineString;
-  helpers.multiPoint;
-  helpers.multiPolygon;
-  helpers.geometryCollection;
-  helpers.round;
-  helpers.radiansToLength;
-  helpers.lengthToRadians;
-  helpers.lengthToDegrees;
-  helpers.bearingToAzimuth;
-  helpers.radiansToDegrees;
-  helpers.degreesToRadians;
-  helpers.convertLength;
-  helpers.convertArea;
-  helpers.isNumber;
-  helpers.isObject;
-  helpers.validateBBox;
-  helpers.validateId;
-  helpers.radians2degrees;
-  helpers.degrees2radians;
-  helpers.distanceToDegrees;
-  helpers.distanceToRadians;
-  helpers.radiansToDistance;
-  helpers.bearingToAngle;
-  helpers.convertDistance;
-
-  var invariant = createCommonjsModule(function (module, exports) {
-  Object.defineProperty(exports, "__esModule", { value: true });
-
   /**
    * Unwrap a coordinate from a Point Feature, Geometry or a single coordinate.
    *
@@ -9166,141 +8419,23 @@ function sendTile(id, tile) {
           throw new Error("coord is required");
       }
       if (!Array.isArray(coord)) {
-          if (coord.type === "Feature" && coord.geometry !== null && coord.geometry.type === "Point") {
+          if (coord.type === "Feature" &&
+              coord.geometry !== null &&
+              coord.geometry.type === "Point") {
               return coord.geometry.coordinates;
           }
           if (coord.type === "Point") {
               return coord.coordinates;
           }
       }
-      if (Array.isArray(coord) && coord.length >= 2 && !Array.isArray(coord[0]) && !Array.isArray(coord[1])) {
+      if (Array.isArray(coord) &&
+          coord.length >= 2 &&
+          !Array.isArray(coord[0]) &&
+          !Array.isArray(coord[1])) {
           return coord;
       }
       throw new Error("coord must be GeoJSON Point or an Array of numbers");
   }
-  exports.getCoord = getCoord;
-  /**
-   * Unwrap coordinates from a Feature, Geometry Object or an Array
-   *
-   * @name getCoords
-   * @param {Array<any>|Geometry|Feature} coords Feature, Geometry Object or an Array
-   * @returns {Array<any>} coordinates
-   * @example
-   * var poly = turf.polygon([[[119.32, -8.7], [119.55, -8.69], [119.51, -8.54], [119.32, -8.7]]]);
-   *
-   * var coords = turf.getCoords(poly);
-   * //= [[[119.32, -8.7], [119.55, -8.69], [119.51, -8.54], [119.32, -8.7]]]
-   */
-  function getCoords(coords) {
-      if (Array.isArray(coords)) {
-          return coords;
-      }
-      // Feature
-      if (coords.type === "Feature") {
-          if (coords.geometry !== null) {
-              return coords.geometry.coordinates;
-          }
-      }
-      else {
-          // Geometry
-          if (coords.coordinates) {
-              return coords.coordinates;
-          }
-      }
-      throw new Error("coords must be GeoJSON Feature, Geometry Object or an Array");
-  }
-  exports.getCoords = getCoords;
-  /**
-   * Checks if coordinates contains a number
-   *
-   * @name containsNumber
-   * @param {Array<any>} coordinates GeoJSON Coordinates
-   * @returns {boolean} true if Array contains a number
-   */
-  function containsNumber(coordinates) {
-      if (coordinates.length > 1 && helpers.isNumber(coordinates[0]) && helpers.isNumber(coordinates[1])) {
-          return true;
-      }
-      if (Array.isArray(coordinates[0]) && coordinates[0].length) {
-          return containsNumber(coordinates[0]);
-      }
-      throw new Error("coordinates must only contain numbers");
-  }
-  exports.containsNumber = containsNumber;
-  /**
-   * Enforce expectations about types of GeoJSON objects for Turf.
-   *
-   * @name geojsonType
-   * @param {GeoJSON} value any GeoJSON object
-   * @param {string} type expected GeoJSON type
-   * @param {string} name name of calling function
-   * @throws {Error} if value is not the expected type.
-   */
-  function geojsonType(value, type, name) {
-      if (!type || !name) {
-          throw new Error("type and name required");
-      }
-      if (!value || value.type !== type) {
-          throw new Error("Invalid input to " + name + ": must be a " + type + ", given " + value.type);
-      }
-  }
-  exports.geojsonType = geojsonType;
-  /**
-   * Enforce expectations about types of {@link Feature} inputs for Turf.
-   * Internally this uses {@link geojsonType} to judge geometry types.
-   *
-   * @name featureOf
-   * @param {Feature} feature a feature with an expected geometry type
-   * @param {string} type expected GeoJSON type
-   * @param {string} name name of calling function
-   * @throws {Error} error if value is not the expected type.
-   */
-  function featureOf(feature, type, name) {
-      if (!feature) {
-          throw new Error("No feature passed");
-      }
-      if (!name) {
-          throw new Error(".featureOf() requires a name");
-      }
-      if (!feature || feature.type !== "Feature" || !feature.geometry) {
-          throw new Error("Invalid input to " + name + ", Feature with geometry required");
-      }
-      if (!feature.geometry || feature.geometry.type !== type) {
-          throw new Error("Invalid input to " + name + ": must be a " + type + ", given " + feature.geometry.type);
-      }
-  }
-  exports.featureOf = featureOf;
-  /**
-   * Enforce expectations about types of {@link FeatureCollection} inputs for Turf.
-   * Internally this uses {@link geojsonType} to judge geometry types.
-   *
-   * @name collectionOf
-   * @param {FeatureCollection} featureCollection a FeatureCollection for which features will be judged
-   * @param {string} type expected GeoJSON type
-   * @param {string} name name of calling function
-   * @throws {Error} if value is not the expected type.
-   */
-  function collectionOf(featureCollection, type, name) {
-      if (!featureCollection) {
-          throw new Error("No featureCollection passed");
-      }
-      if (!name) {
-          throw new Error(".collectionOf() requires a name");
-      }
-      if (!featureCollection || featureCollection.type !== "FeatureCollection") {
-          throw new Error("Invalid input to " + name + ", FeatureCollection required");
-      }
-      for (var _i = 0, _a = featureCollection.features; _i < _a.length; _i++) {
-          var feature = _a[_i];
-          if (!feature || feature.type !== "Feature" || !feature.geometry) {
-              throw new Error("Invalid input to " + name + ", Feature with geometry required");
-          }
-          if (!feature.geometry || feature.geometry.type !== type) {
-              throw new Error("Invalid input to " + name + ": must be a " + type + ", given " + feature.geometry.type);
-          }
-      }
-  }
-  exports.collectionOf = collectionOf;
   /**
    * Get Geometry from Feature or Geometry Object
    *
@@ -9325,52 +8460,6 @@ function sendTile(id, tile) {
       }
       return geojson;
   }
-  exports.getGeom = getGeom;
-  /**
-   * Get GeoJSON object's type, Geometry type is prioritize.
-   *
-   * @param {GeoJSON} geojson GeoJSON object
-   * @param {string} [name="geojson"] name of the variable to display in error message
-   * @returns {string} GeoJSON type
-   * @example
-   * var point = {
-   *   "type": "Feature",
-   *   "properties": {},
-   *   "geometry": {
-   *     "type": "Point",
-   *     "coordinates": [110, 40]
-   *   }
-   * }
-   * var geom = turf.getType(point)
-   * //="Point"
-   */
-  function getType(geojson, name) {
-      if (geojson.type === "FeatureCollection") {
-          return "FeatureCollection";
-      }
-      if (geojson.type === "GeometryCollection") {
-          return "GeometryCollection";
-      }
-      if (geojson.type === "Feature" && geojson.geometry !== null) {
-          return geojson.geometry.type;
-      }
-      return geojson.type;
-  }
-  exports.getType = getType;
-  });
-
-  unwrapExports(invariant);
-  invariant.getCoord;
-  invariant.getCoords;
-  invariant.containsNumber;
-  invariant.geojsonType;
-  invariant.featureOf;
-  invariant.collectionOf;
-  invariant.getGeom;
-  invariant.getType;
-
-  var booleanPointInPolygon_1 = createCommonjsModule(function (module, exports) {
-  Object.defineProperty(exports, "__esModule", { value: true });
 
   // http://en.wikipedia.org/wiki/Even%E2%80%93odd_rule
   // modified from: https://github.com/substack/point-in-polygon/blob/master/index.js
@@ -9408,8 +8497,8 @@ function sendTile(id, tile) {
       if (!polygon) {
           throw new Error("polygon is required");
       }
-      var pt = invariant.getCoord(point);
-      var geom = invariant.getGeom(polygon);
+      var pt = getCoord(point);
+      var geom = getGeom(polygon);
       var type = geom.type;
       var bbox = polygon.bbox;
       var polys = geom.coordinates;
@@ -9441,7 +8530,6 @@ function sendTile(id, tile) {
       }
       return insidePoly;
   }
-  exports.default = booleanPointInPolygon;
   /**
    * inRing
    *
@@ -9453,7 +8541,8 @@ function sendTile(id, tile) {
    */
   function inRing(pt, ring, ignoreBoundary) {
       var isInside = false;
-      if (ring[0][0] === ring[ring.length - 1][0] && ring[0][1] === ring[ring.length - 1][1]) {
+      if (ring[0][0] === ring[ring.length - 1][0] &&
+          ring[0][1] === ring[ring.length - 1][1]) {
           ring = ring.slice(0, ring.length - 1);
       }
       for (var i = 0, j = ring.length - 1; i < ring.length; j = i++) {
@@ -9461,13 +8550,14 @@ function sendTile(id, tile) {
           var yi = ring[i][1];
           var xj = ring[j][0];
           var yj = ring[j][1];
-          var onBoundary = (pt[1] * (xi - xj) + yi * (xj - pt[0]) + yj * (pt[0] - xi) === 0) &&
-              ((xi - pt[0]) * (xj - pt[0]) <= 0) && ((yi - pt[1]) * (yj - pt[1]) <= 0);
+          var onBoundary = pt[1] * (xi - xj) + yi * (xj - pt[0]) + yj * (pt[0] - xi) === 0 &&
+              (xi - pt[0]) * (xj - pt[0]) <= 0 &&
+              (yi - pt[1]) * (yj - pt[1]) <= 0;
           if (onBoundary) {
               return !ignoreBoundary;
           }
-          var intersect = ((yi > pt[1]) !== (yj > pt[1])) &&
-              (pt[0] < (xj - xi) * (pt[1] - yi) / (yj - yi) + xi);
+          var intersect = yi > pt[1] !== yj > pt[1] &&
+              pt[0] < ((xj - xi) * (pt[1] - yi)) / (yj - yi) + xi;
           if (intersect) {
               isInside = !isInside;
           }
@@ -9483,14 +8573,8 @@ function sendTile(id, tile) {
    * @returns {boolean} true/false if point is inside BBox
    */
   function inBBox(pt, bbox) {
-      return bbox[0] <= pt[0] &&
-          bbox[1] <= pt[1] &&
-          bbox[2] >= pt[0] &&
-          bbox[3] >= pt[1];
+      return (bbox[0] <= pt[0] && bbox[1] <= pt[1] && bbox[2] >= pt[0] && bbox[3] >= pt[1]);
   }
-  });
-
-  var booleanPointInPolygon = unwrapExports(booleanPointInPolygon_1);
 
   function initSelector(sources, projection) {
     const tileSize = 512; // TODO: don't assume this
@@ -9547,7 +8631,7 @@ function sendTile(id, tile) {
     }
   }
 
-  function init$2$1(userParams) {
+  function init$3(userParams) {
     const params = setParams$1(userParams);
 
     // Set up dummy API
@@ -9606,7 +8690,7 @@ function sendTile(id, tile) {
     const { context, width, height, style, mapboxToken } = params;
     const framebuffer = context.initFramebuffer({ width, height });
 
-    return init$2$1({ context, framebuffer, style, mapboxToken, units: "radians" })
+    return init$3({ context, framebuffer, style, mapboxToken, units: "radians" })
       .promise.then(api => setup$1(api, context, framebuffer.sampler))
       .catch(console.log);
   }
@@ -11668,11 +10752,10 @@ precision highp sampler2D;
   }
 
   function initGlobe(userParams) {
-    const params = setParams$2(userParams);
+    const params = setParams$3(userParams);
 
     return initMap(params)
-      .then(map => setup(map, params))
-      .catch(console.log);
+      .then(map => setup(map, params));
   }
 
   function setup(map, params) {

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -9027,7 +9027,7 @@ if (!Math.hypot) Math.hypot = function () {
  * @returns {vec3} a new 3D vector
  */
 
-function create() {
+function create$2() {
   var out = new ARRAY_TYPE(3);
 
   if (ARRAY_TYPE != Float32Array) {
@@ -9173,7 +9173,7 @@ function dot(a, b) {
  * @returns {vec3} out
  */
 
-function transformMat4(out, a, m) {
+function transformMat4$1(out, a, m) {
   var x = a[0],
       y = a[1],
       z = a[2];
@@ -9216,7 +9216,7 @@ function transformMat3(out, a, m) {
  */
 
 (function () {
-  var vec = create();
+  var vec = create$2();
   return function (a, stride, offset, count, fn, arg) {
     var i, l;
 
@@ -9246,7 +9246,7 @@ function transformMat3(out, a, m) {
 
     return a;
   };
-}());
+})();
 
 function initEcefToLocalGeo() {
   var sinLon, cosLon, sinLat, cosLat;
@@ -9682,7 +9682,7 @@ function initECEF(ellipsoid, initialPos) {
  * @returns {vec4} a new 4D vector
  */
 
-function create$2() {
+function create() {
   var out = new ARRAY_TYPE(4);
 
   if (ARRAY_TYPE != Float32Array) {
@@ -9703,7 +9703,7 @@ function create$2() {
  * @returns {vec4} out
  */
 
-function transformMat4$1(out, a, m) {
+function transformMat4(out, a, m) {
   var x = a[0],
       y = a[1],
       z = a[2],
@@ -9728,7 +9728,7 @@ function transformMat4$1(out, a, m) {
  */
 
 (function () {
-  var vec = create$2();
+  var vec = create();
   return function (a, stride, offset, count, fn, arg) {
     var i, l;
 
@@ -9760,7 +9760,7 @@ function transformMat4$1(out, a, m) {
 
     return a;
   };
-}());
+})();
 
 function initEdgePoints(ellipsoid, camPos, camRot, screen) {
   // Allocate working arrays and variables
@@ -9813,7 +9813,7 @@ function initEdgePoints(ellipsoid, camPos, camRot, screen) {
     rayVec[0] = screenPos[0] * tanX;
     rayVec[1] = screenPos[1] * tanY;
     // Rotate to model coordinates (Earth-Centered Earth-Fixed)
-    transformMat4$1(camRay, rayVec, camRot);
+    transformMat4(camRay, rayVec, camRot);
 
     // Find intersection of ray with ellipsoid
     var hit = ellipsoid.shoot(rayHit, camPos, camRay);
@@ -10050,7 +10050,7 @@ function initProjector(ellipsoid, camPosition, camInverse, screen) {
     const visible = ( dot(rayVec, ecefPosition) < 0 );
 
     // Rotate to camera orientation
-    transformMat4(screenRay, rayVec, camInverse);
+    transformMat4$1(screenRay, rayVec, camInverse);
 
     // Normalize to z = -1
     screenRay[0] /= -screenRay[2];
@@ -10149,7 +10149,7 @@ function initCameraDynamics(screen, ellipsoid, initialPosition) {
 }
 
 function initCursor3d(getRayParams, ellipsoid, initialPosition) {
-  // Input getRayParams is a method from yawgl.screen, converting screen X/Y
+  // Input getRayParams is a method from yawgl.initView, converting screen X/Y
   //  to a ray shooting into 3D space
   // Input initialPosition is a geodetic lon/lat/alt vector
 
@@ -10206,7 +10206,7 @@ function initCursor3d(getRayParams, ellipsoid, initialPosition) {
   function update(cursor2d, camera) {
     // Get screen ray in model coordinates (ECEF)
     getRayParams(cursorRay, cursor2d.x(), cursor2d.y());
-    transformMat4$1(ecefRay, cursorRay, camera.rotation);
+    transformMat4(ecefRay, cursorRay, camera.rotation);
 
     // Find intersection of ray with ellipsoid
     onScene = ellipsoid.shoot(cursorPosition, camera.ecefPos, ecefRay);

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -539,7 +539,7 @@ var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" clas
 </svg>
 `;
 
-function setParams$2(userParams) {
+function setParams$3(userParams) {
   // Get the containing DIV element, and set its CSS class
   const container = document.getElementById(userParams.container);
   container.classList.add("globelet");
@@ -791,7 +791,7 @@ vec4 mapToClip(vec2 mapPos, float z) {
 }
 `;
 
-var vert = `attribute vec2 quadPos; // Vertices of the quad instance
+var vert$3 = `attribute vec2 quadPos; // Vertices of the quad instance
 attribute vec2 circlePos;
 attribute float radius;
 attribute vec4 color;
@@ -816,7 +816,7 @@ void main() {
 }
 `;
 
-var frag = `precision mediump float;
+var frag$3 = `precision mediump float;
 
 varying vec2 delta;
 varying vec4 strokeStyle;
@@ -916,7 +916,7 @@ function initVectorTilePainter(context, framebufferSize, layerId, setAtlas) {
 function initCircle(context, framebufferSize, preamble) {
   const { initProgram, initQuad, initAttribute } = context;
 
-  const program = initProgram(preamble + vert, frag);
+  const program = initProgram(preamble + vert$3, frag$3);
   const { use, uniformSetters, constructVao } = program;
 
   const grid = initGrid(framebufferSize, use, uniformSetters);
@@ -957,7 +957,7 @@ function initCircle(context, framebufferSize, preamble) {
   return { load, initPainter };
 }
 
-var vert$1 = `attribute vec2 quadPos;
+var vert$2 = `attribute vec2 quadPos;
 attribute vec3 pointA, pointB, pointC, pointD;
 attribute vec4 color;
 attribute float opacity;
@@ -1035,7 +1035,7 @@ void main() {
 }
 `;
 
-var frag$1 = `precision highp float;
+var frag$2 = `precision highp float;
 
 uniform float lineWidth;
 
@@ -1114,7 +1114,7 @@ function initLineLoader(context, constructVao) {
 }
 
 function initLine(context, framebufferSize, preamble) {
-  const program = context.initProgram(preamble + vert$1, frag$1);
+  const program = context.initProgram(preamble + vert$2, frag$2);
   const { use, uniformSetters, constructVao } = program;
 
   const grid = initGrid(framebufferSize, use, uniformSetters);
@@ -1144,7 +1144,7 @@ function initLine(context, framebufferSize, preamble) {
   return { load, initPainter };
 }
 
-var vert$2 = `attribute vec2 position;
+var vert$1 = `attribute vec2 position;
 attribute vec4 color;
 attribute float opacity;
 
@@ -1161,7 +1161,7 @@ void main() {
 }
 `;
 
-var frag$2 = `precision mediump float;
+var frag$1 = `precision mediump float;
 
 varying vec4 fillStyle;
 
@@ -1196,7 +1196,7 @@ function initFillLoader(context, constructVao) {
 }
 
 function initFill(context, framebufferSize, preamble) {
-  const program = context.initProgram(preamble + vert$2, frag$2);
+  const program = context.initProgram(preamble + vert$1, frag$1);
   const { use, uniformSetters, constructVao } = program;
   const grid = initGrid(framebufferSize, use, uniformSetters);
 
@@ -1217,7 +1217,7 @@ function initFill(context, framebufferSize, preamble) {
   return { load, initPainter };
 }
 
-var vert$3 = `attribute vec2 quadPos;  // Vertices of the quad instance
+var vert = `attribute vec2 quadPos;  // Vertices of the quad instance
 attribute vec2 labelPos; // x, y
 attribute vec3 charPos;  // dx, dy, scale (relative to labelPos)
 attribute vec4 sdfRect;  // x, y, w, h
@@ -1241,7 +1241,7 @@ void main() {
 }
 `;
 
-var frag$3 = `precision highp float;
+var frag = `precision highp float;
 
 uniform sampler2D sdf;
 uniform vec2 sdfDim;
@@ -1289,7 +1289,7 @@ function initTextLoader(context, constructVao) {
 }
 
 function initText(context, framebufferSize, preamble) {
-  const program = context.initProgram(preamble + vert$3, frag$3);
+  const program = context.initProgram(preamble + vert, frag);
   const { use, uniformSetters, constructVao } = program;
   const grid = initGrid(framebufferSize, use, uniformSetters);
 
@@ -1410,7 +1410,7 @@ function initEventHandler() {
 function setParams$1(userParams) {
   const gl = userParams.context.gl;
   if (!(gl instanceof WebGLRenderingContext)) {
-    fail("no valid WebGL context");
+    fail$1("no valid WebGL context");
   }
 
   const {
@@ -1426,28 +1426,28 @@ function setParams$1(userParams) {
 
   const { buffer, size } = framebuffer;
   if (!(buffer instanceof WebGLFramebuffer) && buffer !== null) {
-    fail("no valid framebuffer");
+    fail$1("no valid framebuffer");
   }
 
   if (!size || !allPosInts(size.width, size.height)) {
-    fail("invalid size object");
+    fail$1("invalid size object");
   }
 
   if (!Array.isArray(center) || center.length < 2) {
-    fail("invalid center coordinates");
+    fail$1("invalid center coordinates");
   }
 
   if (!Number.isFinite(zoom)) {
-    fail("invalid zoom value");
+    fail$1("invalid zoom value");
   }
 
   const validUnits = ["degrees", "radians", "xy"];
-  if (!validUnits.includes(units)) fail("invalid units");
+  if (!validUnits.includes(units)) fail$1("invalid units");
   const projection = getProjection(units);
 
   // Convert initial center position from degrees to the specified units
   const projCenter = getProjection("degrees").forward(center);
-  if (!all0to1(...projCenter)) fail ("invalid center coordinates");
+  if (!all0to1(...projCenter)) fail$1 ("invalid center coordinates");
   const invCenter = projection.inverse(projCenter);
 
   return {
@@ -1460,7 +1460,7 @@ function setParams$1(userParams) {
   };
 }
 
-function fail(message) {
+function fail$1(message) {
   throw Error("tile-setter parameter check: " + message + "!");
 }
 
@@ -1473,24 +1473,24 @@ function all0to1(...vals) {
 }
 
 function expandStyleURL(url, token) {
-  var prefix = /^mapbox:\/\/styles\//;
+  const prefix = /^mapbox:\/\/styles\//;
   if ( !url.match(prefix) ) return url;
-  var apiRoot = "https://api.mapbox.com/styles/v1/";
+  const apiRoot = "https://api.mapbox.com/styles/v1/";
   return url.replace(prefix, apiRoot) + "?access_token=" + token;
 }
 
 function expandSpriteURLs(url, token) {
   // Returns an array containing urls to .png and .json files
-  var prefix = /^mapbox:\/\/sprites\//;
+  const prefix = /^mapbox:\/\/sprites\//;
   if ( !url.match(prefix) ) return {
     image: url + ".png", 
     meta: url + ".json",
   };
 
   // We have a Mapbox custom url. Expand to an absolute URL, as per the spec
-  var apiRoot = "https://api.mapbox.com/styles/v1/";
+  const apiRoot = "https://api.mapbox.com/styles/v1/";
   url = url.replace(prefix, apiRoot) + "/sprite";
-  var tokenString = "?access_token=" + token;
+  const tokenString = "?access_token=" + token;
   return {
     image: url + ".png" + tokenString, 
     meta: url + ".json" + tokenString,
@@ -1498,50 +1498,57 @@ function expandSpriteURLs(url, token) {
 }
 
 function expandTileURL(url, token) {
-  var prefix = /^mapbox:\/\//;
+  const prefix = /^mapbox:\/\//;
   if ( !url.match(prefix) ) return url;
-  var apiRoot = "https://api.mapbox.com/v4/";
+  const apiRoot = "https://api.mapbox.com/v4/";
   return url.replace(prefix, apiRoot) + ".json?secure&access_token=" + token;
 }
 
 function expandGlyphURL(url, token) {
-  var prefix = /^mapbox:\/\/fonts\//;
+  const prefix = /^mapbox:\/\/fonts\//;
   if ( !url.match(prefix) ) return url;
-  var apiRoot = "https://api.mapbox.com/fonts/v1/";
+  const apiRoot = "https://api.mapbox.com/fonts/v1/";
   return url.replace(prefix, apiRoot) + "?access_token=" + token;
 }
 
-function getJSON(data) {
-  switch (typeof data) {
-    case "object":
-      // data may be GeoJSON already. Confirm and return
-      return (data !== null && data.type)
-        ? Promise.resolve(data)
-        : Promise.reject(data);
+function getGeoJSON(data) {
+  const dataPromise = (typeof data === "object" && data !== null)
+    ? Promise.resolve(data)
+    : getJSON(data); // data may be a URL. Try loading it
 
-    case "string":
-      // data must be a URL
-      return fetch(data).then(response => {
-        return (response.ok)
-          ? response.json()
-          : Promise.reject(response);
-      });
+  return dataPromise.then(json => {
+    // Is it valid GeoJSON? For now, just check for a .type property
+    return (json.type)
+      ? json
+      : Promise.reject(Error("invalid GeoJSON: " + JSON.stringify(json)));
+  });
+}
 
-    default:
-      return Promise.reject(data);
+function getJSON(href) {
+  return (typeof href === "string" && href.length)
+    ? fetch(href).then(checkFetch)
+    : Promise.reject(Error("invalid URL: " + JSON.stringify(href)));
+}
+
+function checkFetch(response) {
+  if (!response.ok) {
+    const { status, statusText, url } = response;
+    const message = ["HTTP", status, statusText, "for URL", url].join(" ");
+    return Promise.reject(Error(message));
   }
+
+  return response.json();
 }
 
 function getImage(href) {
-  const errMsg = "ERROR in getImage for href " + href;
   const img = new Image();
 
   return new Promise( (resolve, reject) => {
-    img.onerror = () => reject(errMsg);
+    img.onerror = () => reject(Error("Failed to retrieve image from " + href));
 
     img.onload = () => (img.complete && img.naturalWidth !== 0)
         ? resolve(img)
-        : reject(errMsg);
+        : reject(Error("Incomplete image received from " + href));
 
     img.crossOrigin = "anonymous";
     img.src = href;
@@ -2272,18 +2279,18 @@ function deref(layer, parent) {
 }
 
 function loadLinks(styleDoc, mapboxToken) {
-  styleDoc.layers = derefLayers(styleDoc.layers);
-  if (styleDoc.glyphs) {
-    styleDoc.glyphs = expandGlyphURL(styleDoc.glyphs, mapboxToken);
+  const { sources: rawSources, glyphs, sprite, layers } = styleDoc;
+
+  styleDoc.layers = derefLayers(layers);
+  if (glyphs) {
+    styleDoc.glyphs = expandGlyphURL(glyphs, mapboxToken);
   }
 
   return Promise.all([
-    expandSources(styleDoc.sources, mapboxToken),
-    loadSprite(styleDoc.sprite, mapboxToken),
-  ]).then( ([sources, spriteData]) => {
-    styleDoc.sources = sources;
-    styleDoc.spriteData = spriteData;
-    return styleDoc;
+    expandSources(rawSources, mapboxToken),
+    loadSprite(sprite, mapboxToken),
+  ]).then(([sources, spriteData]) => {
+    return Object.assign(styleDoc, { sources, spriteData });
   });
 }
 
@@ -2291,30 +2298,34 @@ function expandSources(rawSources, token) {
   const expandPromises = Object.entries(rawSources).map(expandSource);
 
   function expandSource([key, source]) {
-    if (source.type === "geojson") {
-      return getJSON(source.data).then(JSON => {
-        source.data = JSON;
-        return [key, source];
-      });
+    const { type, url } = source;
+
+    const infoPromise =
+      (type === "geojson") ? getGeoJSON(source.data).then(data => ({ data }))
+      : (url) ? getJSON(expandTileURL(url, token)) // Get linked TileJSON
+      : Promise.resolve({}); // No linked info
+
+    return infoPromise.then(info => {
+      // Assign everything to a new object for return.
+      // Note: shallow copy! Some properties may point back to the original
+      // style document, like .vector_layers, .bounds, .center, .extent
+      const updatedSource = Object.assign({}, source, info, { type });
+      return { [key]: updatedSource };
+    });
+  }
+
+  return Promise.allSettled(expandPromises)
+    .then(results => results.reduce(processResult, {}));
+
+  function processResult(sources, result) {
+    if (result.status === "fulfilled") {
+      return Object.assign(sources, result.value);
+    } else {
+      // If one source fails to load, just log the reason and move on
+      warn("Error loading sources: " + result.reason.message);
+      return sources;
     }
-
-    // If no .url, return a shallow copy of the input. 
-    // Note: some properties may still be pointing back to the original 
-    // style document, like .vector_layers, .bounds, .center, .extent
-    if (source.url === undefined) return [key, Object.assign({}, source)];
-
-    // Load the referenced TileJSON document, add any values from source
-    return getJSON( expandTileURL(source.url, token) )
-      .then( tileJson => [key, Object.assign(tileJson, source)] );
   }
-
-  function combineSources(keySourcePairs) {
-    const sources = {};
-    keySourcePairs.forEach( ([key, val]) => { sources[key] = val; } );
-    return sources;
-  }
-
-  return Promise.all( expandPromises ).then( combineSources );
 }
 
 function loadSprite(sprite, token) {
@@ -2323,7 +2334,17 @@ function loadSprite(sprite, token) {
   const urls = expandSpriteURLs(sprite, token);
 
   return Promise.all([getImage(urls.image), getJSON(urls.meta)])
-    .then( ([image, meta]) => ({ image, meta }) );
+    .then( ([image, meta]) => ({ image, meta }) )
+    .catch(err => {
+      // If sprite doesn't load, just log the error and move on
+      warn("Error loading sprite: " + err.message);
+    });
+}
+
+function warn(message) {
+  console.log("tile-stencil had a problem loading part of the style document");
+  console.log("  " + message);
+  console.log("  Not a fatal error. Proceeding with the rest of the style...");
 }
 
 function getStyleFuncs(inputLayer) {
@@ -2343,13 +2364,28 @@ function loadStyle(style, mapboxToken) {
     ? Promise.resolve(style)                // style is JSON already
     : getJSON( expandStyleURL(style, mapboxToken) ); // Get from URL
 
-  return getStyle
+  return getStyle.then(checkStyle)
     .then( styleDoc => loadLinks(styleDoc, mapboxToken) );
 }
 
-initZeroTimeouts();
+function checkStyle(doc) {
+  const { version, sources, layers } = doc;
 
-function initZeroTimeouts() {
+  const error =
+    (typeof sources !== "object" || sources === null || Array.isArray(sources))
+    ? "missing sources object"
+    : (!Array.isArray(layers))
+    ? "missing layers array"
+    : (version !== 8)
+    ? "unsupported version number"
+    : null;
+
+  return (error) ? Promise.reject(error) : doc;
+}
+
+initZeroTimeouts$1();
+
+function initZeroTimeouts$1() {
   // setTimeout with true zero delay. https://github.com/GlobeletJS/zero-timeout
   const timeouts = [];
   var taskId = 0;
@@ -2444,9 +2480,9 @@ function init$2() {
   }
 }
 
-initZeroTimeouts$1();
+initZeroTimeouts();
 
-function initZeroTimeouts$1() {
+function initZeroTimeouts() {
   // setTimeout with true zero delay. https://github.com/GlobeletJS/zero-timeout
   const timeouts = [];
   var taskId = 0;
@@ -2543,7 +2579,7 @@ function init$1$1() {
 
 const vectorTypes = ["symbol", "circle", "line", "fill"];
 
-function setParams$1$1(userParams) {
+function setParams$2(userParams) {
   const {
     threads = 2,
     context,
@@ -2555,18 +2591,18 @@ function setParams$1$1(userParams) {
   } = userParams;
 
   // Confirm supplied styles are all vector layers reading from the same source
-  if (!layers || !layers.length) fail$1("no valid array of style layers!");
+  if (!layers || !layers.length) fail("no valid array of style layers!");
 
   let allVectors = layers.every( l => vectorTypes.includes(l.type) );
-  if (!allVectors) fail$1("not all layers are vector types!");
+  if (!allVectors) fail("not all layers are vector types!");
 
   let sameSource = layers.every( l => l.source === layers[0].source );
-  if (!sameSource) fail$1("supplied layers use different sources!");
+  if (!sameSource) fail("supplied layers use different sources!");
 
-  if (!source) fail$1("parameters.source is required!");
+  if (!source) fail("parameters.source is required!");
 
   if (source.type === "vector" && !(source.tiles && source.tiles.length)) {
-    fail$1("no valid vector tile endpoints!");
+    fail("no valid vector tile endpoints!");
   }
 
   return {
@@ -2580,7 +2616,7 @@ function setParams$1$1(userParams) {
   };
 }
 
-function fail$1(message) {
+function fail(message) {
   throw Error("ERROR in tile-mixer: " + message);
 }
 
@@ -2665,7 +2701,7 @@ var workerCode = String.raw`function define(constructor, factory, prototype) {
   prototype.constructor = constructor;
 }
 
-function extend(parent, definition) {
+function extend$2(parent, definition) {
   var prototype = Object.create(parent.prototype);
   for (var key in definition) prototype[key] = definition[key];
   return prototype;
@@ -2910,7 +2946,7 @@ function Rgb(r, g, b, opacity) {
   this.opacity = +opacity;
 }
 
-define(Rgb, rgb, extend(Color, {
+define(Rgb, rgb, extend$2(Color, {
   brighter: function(k) {
     k = k == null ? brighter : Math.pow(brighter, k);
     return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
@@ -2996,7 +3032,7 @@ function Hsl(h, s, l, opacity) {
   this.opacity = +opacity;
 }
 
-define(Hsl, hsl, extend(Color, {
+define(Hsl, hsl, extend$2(Color, {
   brighter: function(k) {
     k = k == null ? brighter : Math.pow(brighter, k);
     return new Hsl(this.h, this.s, this.l * k, this.opacity);
@@ -3330,19 +3366,9 @@ const paintDefaults = {
   },
 };
 
-function getStyleFuncs(inputLayer) {
-  const layer = Object.assign({}, inputLayer); // Leave input unchanged
-
-  // Replace rendering properties with functions
-  layer.layout = autoGetters(layer.layout, layoutDefaults[layer.type]);
-  layer.paint  = autoGetters(layer.paint,  paintDefaults[layer.type] );
-
-  return layer;
-}
-
 function buildFeatureFilter(filterObj) {
   // filterObj is a filter definition following the "deprecated" syntax:
-  // https://docs.mapbox.com/mapbox-gl-js/style-spec/#other-filter
+  // https://maplibre.org/maplibre-gl-js-docs/style-spec/other/#other-filter
   if (!filterObj) return () => true;
   const [type, ...vals] = filterObj;
 
@@ -3420,6 +3446,16 @@ function initFeatureValGetter(key) {
   }
 }
 
+function getStyleFuncs(inputLayer) {
+  const layer = Object.assign({}, inputLayer); // Leave input unchanged
+
+  // Replace rendering properties with functions
+  layer.layout = autoGetters(layer.layout, layoutDefaults[layer.type]);
+  layer.paint  = autoGetters(layer.paint,  paintDefaults[layer.type] );
+
+  return layer;
+}
+
 function initSourceFilter(styles) {
   const filters = styles.map(initLayerFilter);
 
@@ -3471,8 +3507,11 @@ function getGeomFilter(type) {
   }
 }
 
+var ieee754$1 = {};
+
 /*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> */
-var read = function (buffer, offset, isLE, mLen, nBytes) {
+
+ieee754$1.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m;
   var eLen = (nBytes * 8) - mLen - 1;
   var eMax = (1 << eLen) - 1;
@@ -3505,7 +3544,7 @@ var read = function (buffer, offset, isLE, mLen, nBytes) {
   return (s ? -1 : 1) * m * Math.pow(2, e - mLen)
 };
 
-var write = function (buffer, value, offset, isLE, mLen, nBytes) {
+ieee754$1.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   var e, m, c;
   var eLen = (nBytes * 8) - mLen - 1;
   var eMax = (1 << eLen) - 1;
@@ -3557,14 +3596,9 @@ var write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128;
 };
 
-var ieee754 = {
-	read: read,
-	write: write
-};
-
 var pbf = Pbf;
 
-
+var ieee754 = ieee754$1;
 
 function Pbf(buf) {
     this.buf = ArrayBuffer.isView && ArrayBuffer.isView(buf) ? buf : new Uint8Array(buf || 0);
@@ -4288,7 +4322,7 @@ function outOfRange(point, size, image) {
   );
 }
 
-const GLYPH_PBF_BORDER = 3;
+const GLYPH_PBF_BORDER$1 = 3;
 
 function parseGlyphPbf(data) {
   // See mapbox-gl-js/src/style/parse_glyph_pbf.js
@@ -4306,7 +4340,7 @@ function readFontstack(tag, glyphs, pbf) {
   const glyph = pbf.readMessage(readGlyph, {});
   const { id, bitmap, width, height, left, top, advance } = glyph;
 
-  const borders = 2 * GLYPH_PBF_BORDER;
+  const borders = 2 * GLYPH_PBF_BORDER$1;
   const size = { width: width + borders, height: height + borders };
 
   glyphs.push({
@@ -4456,7 +4490,7 @@ function potpack(boxes) {
     };
 }
 
-const ATLAS_PADDING = 1;
+const ATLAS_PADDING$1 = 1;
 
 function buildAtlas(fonts) {
   // See mapbox-gl-js/src/render/glyph_atlas.js
@@ -4498,8 +4532,8 @@ function getPosition(glyph) {
   if (width === 0 || height === 0) return;
 
   // Construct a preliminary rect, positioned at the origin for now
-  let w = width + 2 * ATLAS_PADDING;
-  let h = height + 2 * ATLAS_PADDING;
+  let w = width + 2 * ATLAS_PADDING$1;
+  let h = height + 2 * ATLAS_PADDING$1;
   let rect = { x: 0, y: 0, w, h };
 
   return { metrics, rect };
@@ -4512,7 +4546,7 @@ function copyGlyphBitmap(glyph, positions, image) {
 
   let srcPt = { x: 0, y: 0 };
   let { x, y } = position.rect;
-  let dstPt = { x: x + ATLAS_PADDING, y: y + ATLAS_PADDING };
+  let dstPt = { x: x + ATLAS_PADDING$1, y: y + ATLAS_PADDING$1 };
   AlphaImage.copy(bitmap, image, srcPt, dstPt, bitmap);
 }
 
@@ -4758,8 +4792,10 @@ function flattenLinearRing(ring) {
   ];
 }
 
-var earcut_1 = earcut;
-var default_1 = earcut;
+var earcut$2 = {exports: {}};
+
+earcut$2.exports = earcut;
+earcut$2.exports.default = earcut;
 
 function earcut(data, holeIndices, dim) {
 
@@ -4804,7 +4840,7 @@ function earcut(data, holeIndices, dim) {
 function linkedList(data, start, end, dim, clockwise) {
     var i, last;
 
-    if (clockwise === (signedArea(data, start, end, dim) > 0)) {
+    if (clockwise === (signedArea$1(data, start, end, dim) > 0)) {
         for (i = start; i < end; i += dim) last = insertNode(i, data[i], data[i + 1], last);
     } else {
         for (i = end - dim; i >= start; i -= dim) last = insertNode(i, data[i], data[i + 1], last);
@@ -4974,7 +5010,7 @@ function cureLocalIntersections(start, triangles, dim) {
         var a = p.prev,
             b = p.next.next;
 
-        if (!equals(a, b) && intersects(a, p, p.next, b) && locallyInside(a, b) && locallyInside(b, a)) {
+        if (!equals(a, b) && intersects$1(a, p, p.next, b) && locallyInside(a, b) && locallyInside(b, a)) {
 
             triangles.push(a.i / dim);
             triangles.push(p.i / dim);
@@ -5249,7 +5285,7 @@ function equals(p1, p2) {
 }
 
 // check if two segments intersect
-function intersects(p1, q1, p2, q2) {
+function intersects$1(p1, q1, p2, q2) {
     var o1 = sign(area(p1, q1, p2));
     var o2 = sign(area(p1, q1, q2));
     var o3 = sign(area(p2, q2, p1));
@@ -5279,7 +5315,7 @@ function intersectsPolygon(a, b) {
     var p = a;
     do {
         if (p.i !== a.i && p.next.i !== a.i && p.i !== b.i && p.next.i !== b.i &&
-                intersects(p, p.next, a, b)) return true;
+                intersects$1(p, p.next, a, b)) return true;
         p = p.next;
     } while (p !== a);
 
@@ -5386,12 +5422,12 @@ earcut.deviation = function (data, holeIndices, dim, triangles) {
     var hasHoles = holeIndices && holeIndices.length;
     var outerLen = hasHoles ? holeIndices[0] * dim : data.length;
 
-    var polygonArea = Math.abs(signedArea(data, 0, outerLen, dim));
+    var polygonArea = Math.abs(signedArea$1(data, 0, outerLen, dim));
     if (hasHoles) {
         for (var i = 0, len = holeIndices.length; i < len; i++) {
             var start = holeIndices[i] * dim;
             var end = i < len - 1 ? holeIndices[i + 1] * dim : data.length;
-            polygonArea -= Math.abs(signedArea(data, start, end, dim));
+            polygonArea -= Math.abs(signedArea$1(data, start, end, dim));
         }
     }
 
@@ -5409,7 +5445,7 @@ earcut.deviation = function (data, holeIndices, dim, triangles) {
         Math.abs((trianglesArea - polygonArea) / polygonArea);
 };
 
-function signedArea(data, start, end, dim) {
+function signedArea$1(data, start, end, dim) {
     var sum = 0;
     for (var i = start, j = end - dim; i < end; i += dim) {
         sum += (data[j] - data[i]) * (data[i + 1] + data[j + 1]);
@@ -5435,7 +5471,8 @@ earcut.flatten = function (data) {
     }
     return result;
 };
-earcut_1.default = default_1;
+
+var earcut$1 = earcut$2.exports;
 
 function initFillParsing(style) {
   const { paint } = style;
@@ -5485,17 +5522,17 @@ function triangulate(geometry) {
 }
 
 function indexPolygon(coords) {
-  let { vertices, holes, dimensions } = earcut_1.flatten(coords);
-  let indices = earcut_1(vertices, holes, dimensions);
+  let { vertices, holes, dimensions } = earcut$1.flatten(coords);
+  let indices = earcut$1(vertices, holes, dimensions);
   return { vertices, indices };
 }
 
-const GLYPH_PBF_BORDER$1 = 3;
+const GLYPH_PBF_BORDER = 3;
 const ONE_EM = 24;
 
-const ATLAS_PADDING$1 = 1;
+const ATLAS_PADDING = 1;
 
-const RECT_BUFFER = GLYPH_PBF_BORDER$1 + ATLAS_PADDING$1;
+const RECT_BUFFER = GLYPH_PBF_BORDER + ATLAS_PADDING;
 
 function layoutLine(glyphs, origin, spacing, scalar) {
   var xCursor = origin[0];
@@ -5949,7 +5986,7 @@ class RBush {
         let node = this.data;
         const result = [];
 
-        if (!intersects$1(bbox, node)) return result;
+        if (!intersects(bbox, node)) return result;
 
         const toBBox = this.toBBox;
         const nodesToSearch = [];
@@ -5959,7 +5996,7 @@ class RBush {
                 const child = node.children[i];
                 const childBBox = node.leaf ? toBBox(child) : child;
 
-                if (intersects$1(bbox, childBBox)) {
+                if (intersects(bbox, childBBox)) {
                     if (node.leaf) result.push(child);
                     else if (contains(bbox, childBBox)) this._all(child, result);
                     else nodesToSearch.push(child);
@@ -5974,7 +6011,7 @@ class RBush {
     collides(bbox) {
         let node = this.data;
 
-        if (!intersects$1(bbox, node)) return false;
+        if (!intersects(bbox, node)) return false;
 
         const nodesToSearch = [];
         while (node) {
@@ -5982,7 +6019,7 @@ class RBush {
                 const child = node.children[i];
                 const childBBox = node.leaf ? this.toBBox(child) : child;
 
-                if (intersects$1(bbox, childBBox)) {
+                if (intersects(bbox, childBBox)) {
                     if (node.leaf || contains(bbox, childBBox)) return true;
                     nodesToSearch.push(child);
                 }
@@ -6120,7 +6157,7 @@ class RBush {
         if (N <= M) {
             // reached leaf level; return leaf
             node = createNode(items.slice(left, right + 1));
-            calcBBox(node, this.toBBox);
+            calcBBox$1(node, this.toBBox);
             return node;
         }
 
@@ -6158,7 +6195,7 @@ class RBush {
             }
         }
 
-        calcBBox(node, this.toBBox);
+        calcBBox$1(node, this.toBBox);
 
         return node;
     }
@@ -6236,8 +6273,8 @@ class RBush {
         newNode.height = node.height;
         newNode.leaf = node.leaf;
 
-        calcBBox(node, this.toBBox);
-        calcBBox(newNode, this.toBBox);
+        calcBBox$1(node, this.toBBox);
+        calcBBox$1(newNode, this.toBBox);
 
         if (level) insertPath[level - 1].children.push(newNode);
         else this._splitRoot(node, newNode);
@@ -6248,7 +6285,7 @@ class RBush {
         this.data = createNode([node, newNode]);
         this.data.height = node.height + 1;
         this.data.leaf = false;
-        calcBBox(this.data, this.toBBox);
+        calcBBox$1(this.data, this.toBBox);
     }
 
     _chooseSplitIndex(node, m, M) {
@@ -6335,7 +6372,7 @@ class RBush {
 
                 } else this.clear();
 
-            } else calcBBox(path[i], this.toBBox);
+            } else calcBBox$1(path[i], this.toBBox);
         }
     }
 }
@@ -6350,7 +6387,7 @@ function findItem(item, items, equalsFn) {
 }
 
 // calculate node's bbox from bboxes of its children
-function calcBBox(node, toBBox) {
+function calcBBox$1(node, toBBox) {
     distBBox(node, 0, node.children.length, toBBox, node);
 }
 
@@ -6406,7 +6443,7 @@ function contains(a, b) {
            b.maxY <= a.maxY;
 }
 
-function intersects$1(a, b) {
+function intersects(a, b) {
     return b.minX <= a.maxX &&
            b.minY <= a.maxY &&
            b.maxX >= a.minX &&
@@ -6518,7 +6555,7 @@ function classifyRings(rings) {
   var polygon, ccw;
 
   rings.forEach(ring => {
-    let area = signedArea$1(ring);
+    let area = signedArea(ring);
     if (area === 0) return;
 
     if (ccw === undefined) ccw = area < 0;
@@ -6536,7 +6573,7 @@ function classifyRings(rings) {
   return polygons;
 }
 
-function signedArea$1(ring) {
+function signedArea(ring) {
   const xmul = (p1, p2) => (p2.x - p1.x) * (p1.y + p2.y);
 
   const initialValue = xmul(ring[0], ring[ring.length - 1]);
@@ -6932,11 +6969,11 @@ function createFeature(id, type, geom, tags) {
         maxX: -Infinity,
         maxY: -Infinity
     };
-    calcBBox$1(feature);
+    calcBBox(feature);
     return feature;
 }
 
-function calcBBox$1(feature) {
+function calcBBox(feature) {
     var geom = feature.geometry;
     var type = feature.type;
 
@@ -7552,7 +7589,7 @@ function geojsonvt(data, options) {
 }
 
 function GeoJSONVT(data, options) {
-    options = this.options = extend$2(Object.create(this.options), options);
+    options = this.options = extend(Object.create(this.options), options);
 
     var debug = options.debug;
 
@@ -7736,7 +7773,7 @@ function toID(z, x, y) {
     return (((1 << z) * y + x) * 32) + z;
 }
 
-function extend$2(dest, src) {
+function extend(dest, src) {
     for (var i in src) dest[i] = src[i];
     return dest;
 }
@@ -7845,7 +7882,7 @@ function sendTile(id, tile) {
 `;
 
 function initTileMixer(userParams) {
-  const params = setParams$1$1(userParams);
+  const params = setParams$2(userParams);
   const { queue, context: { loadBuffers, loadAtlas } } = params;
 
   // Initialize workers
@@ -8362,790 +8399,6 @@ function transformCoords(type, coordinates, transform) {
   }
 }
 
-function unwrapExports (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-}
-
-function createCommonjsModule(fn, module) {
-	return module = { exports: {} }, fn(module, module.exports), module.exports;
-}
-
-var helpers = createCommonjsModule(function (module, exports) {
-Object.defineProperty(exports, "__esModule", { value: true });
-/**
- * @module helpers
- */
-/**
- * Earth Radius used with the Harvesine formula and approximates using a spherical (non-ellipsoid) Earth.
- *
- * @memberof helpers
- * @type {number}
- */
-exports.earthRadius = 6371008.8;
-/**
- * Unit of measurement factors using a spherical (non-ellipsoid) earth radius.
- *
- * @memberof helpers
- * @type {Object}
- */
-exports.factors = {
-    centimeters: exports.earthRadius * 100,
-    centimetres: exports.earthRadius * 100,
-    degrees: exports.earthRadius / 111325,
-    feet: exports.earthRadius * 3.28084,
-    inches: exports.earthRadius * 39.370,
-    kilometers: exports.earthRadius / 1000,
-    kilometres: exports.earthRadius / 1000,
-    meters: exports.earthRadius,
-    metres: exports.earthRadius,
-    miles: exports.earthRadius / 1609.344,
-    millimeters: exports.earthRadius * 1000,
-    millimetres: exports.earthRadius * 1000,
-    nauticalmiles: exports.earthRadius / 1852,
-    radians: 1,
-    yards: exports.earthRadius / 1.0936,
-};
-/**
- * Units of measurement factors based on 1 meter.
- *
- * @memberof helpers
- * @type {Object}
- */
-exports.unitsFactors = {
-    centimeters: 100,
-    centimetres: 100,
-    degrees: 1 / 111325,
-    feet: 3.28084,
-    inches: 39.370,
-    kilometers: 1 / 1000,
-    kilometres: 1 / 1000,
-    meters: 1,
-    metres: 1,
-    miles: 1 / 1609.344,
-    millimeters: 1000,
-    millimetres: 1000,
-    nauticalmiles: 1 / 1852,
-    radians: 1 / exports.earthRadius,
-    yards: 1 / 1.0936,
-};
-/**
- * Area of measurement factors based on 1 square meter.
- *
- * @memberof helpers
- * @type {Object}
- */
-exports.areaFactors = {
-    acres: 0.000247105,
-    centimeters: 10000,
-    centimetres: 10000,
-    feet: 10.763910417,
-    inches: 1550.003100006,
-    kilometers: 0.000001,
-    kilometres: 0.000001,
-    meters: 1,
-    metres: 1,
-    miles: 3.86e-7,
-    millimeters: 1000000,
-    millimetres: 1000000,
-    yards: 1.195990046,
-};
-/**
- * Wraps a GeoJSON {@link Geometry} in a GeoJSON {@link Feature}.
- *
- * @name feature
- * @param {Geometry} geometry input geometry
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {Feature} a GeoJSON Feature
- * @example
- * var geometry = {
- *   "type": "Point",
- *   "coordinates": [110, 50]
- * };
- *
- * var feature = turf.feature(geometry);
- *
- * //=feature
- */
-function feature(geom, properties, options) {
-    if (options === void 0) { options = {}; }
-    var feat = { type: "Feature" };
-    if (options.id === 0 || options.id) {
-        feat.id = options.id;
-    }
-    if (options.bbox) {
-        feat.bbox = options.bbox;
-    }
-    feat.properties = properties || {};
-    feat.geometry = geom;
-    return feat;
-}
-exports.feature = feature;
-/**
- * Creates a GeoJSON {@link Geometry} from a Geometry string type & coordinates.
- * For GeometryCollection type use `helpers.geometryCollection`
- *
- * @name geometry
- * @param {string} type Geometry Type
- * @param {Array<any>} coordinates Coordinates
- * @param {Object} [options={}] Optional Parameters
- * @returns {Geometry} a GeoJSON Geometry
- * @example
- * var type = "Point";
- * var coordinates = [110, 50];
- * var geometry = turf.geometry(type, coordinates);
- * // => geometry
- */
-function geometry(type, coordinates, options) {
-    switch (type) {
-        case "Point": return point(coordinates).geometry;
-        case "LineString": return lineString(coordinates).geometry;
-        case "Polygon": return polygon(coordinates).geometry;
-        case "MultiPoint": return multiPoint(coordinates).geometry;
-        case "MultiLineString": return multiLineString(coordinates).geometry;
-        case "MultiPolygon": return multiPolygon(coordinates).geometry;
-        default: throw new Error(type + " is invalid");
-    }
-}
-exports.geometry = geometry;
-/**
- * Creates a {@link Point} {@link Feature} from a Position.
- *
- * @name point
- * @param {Array<number>} coordinates longitude, latitude position (each in decimal degrees)
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {Feature<Point>} a Point feature
- * @example
- * var point = turf.point([-75.343, 39.984]);
- *
- * //=point
- */
-function point(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    var geom = {
-        type: "Point",
-        coordinates: coordinates,
-    };
-    return feature(geom, properties, options);
-}
-exports.point = point;
-/**
- * Creates a {@link Point} {@link FeatureCollection} from an Array of Point coordinates.
- *
- * @name points
- * @param {Array<Array<number>>} coordinates an array of Points
- * @param {Object} [properties={}] Translate these properties to each Feature
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north]
- * associated with the FeatureCollection
- * @param {string|number} [options.id] Identifier associated with the FeatureCollection
- * @returns {FeatureCollection<Point>} Point Feature
- * @example
- * var points = turf.points([
- *   [-75, 39],
- *   [-80, 45],
- *   [-78, 50]
- * ]);
- *
- * //=points
- */
-function points(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    return featureCollection(coordinates.map(function (coords) {
-        return point(coords, properties);
-    }), options);
-}
-exports.points = points;
-/**
- * Creates a {@link Polygon} {@link Feature} from an Array of LinearRings.
- *
- * @name polygon
- * @param {Array<Array<Array<number>>>} coordinates an array of LinearRings
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {Feature<Polygon>} Polygon Feature
- * @example
- * var polygon = turf.polygon([[[-5, 52], [-4, 56], [-2, 51], [-7, 54], [-5, 52]]], { name: 'poly1' });
- *
- * //=polygon
- */
-function polygon(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    for (var _i = 0, coordinates_1 = coordinates; _i < coordinates_1.length; _i++) {
-        var ring = coordinates_1[_i];
-        if (ring.length < 4) {
-            throw new Error("Each LinearRing of a Polygon must have 4 or more Positions.");
-        }
-        for (var j = 0; j < ring[ring.length - 1].length; j++) {
-            // Check if first point of Polygon contains two numbers
-            if (ring[ring.length - 1][j] !== ring[0][j]) {
-                throw new Error("First and last Position are not equivalent.");
-            }
-        }
-    }
-    var geom = {
-        type: "Polygon",
-        coordinates: coordinates,
-    };
-    return feature(geom, properties, options);
-}
-exports.polygon = polygon;
-/**
- * Creates a {@link Polygon} {@link FeatureCollection} from an Array of Polygon coordinates.
- *
- * @name polygons
- * @param {Array<Array<Array<Array<number>>>>} coordinates an array of Polygon coordinates
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the FeatureCollection
- * @returns {FeatureCollection<Polygon>} Polygon FeatureCollection
- * @example
- * var polygons = turf.polygons([
- *   [[[-5, 52], [-4, 56], [-2, 51], [-7, 54], [-5, 52]]],
- *   [[[-15, 42], [-14, 46], [-12, 41], [-17, 44], [-15, 42]]],
- * ]);
- *
- * //=polygons
- */
-function polygons(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    return featureCollection(coordinates.map(function (coords) {
-        return polygon(coords, properties);
-    }), options);
-}
-exports.polygons = polygons;
-/**
- * Creates a {@link LineString} {@link Feature} from an Array of Positions.
- *
- * @name lineString
- * @param {Array<Array<number>>} coordinates an array of Positions
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {Feature<LineString>} LineString Feature
- * @example
- * var linestring1 = turf.lineString([[-24, 63], [-23, 60], [-25, 65], [-20, 69]], {name: 'line 1'});
- * var linestring2 = turf.lineString([[-14, 43], [-13, 40], [-15, 45], [-10, 49]], {name: 'line 2'});
- *
- * //=linestring1
- * //=linestring2
- */
-function lineString(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    if (coordinates.length < 2) {
-        throw new Error("coordinates must be an array of two or more positions");
-    }
-    var geom = {
-        type: "LineString",
-        coordinates: coordinates,
-    };
-    return feature(geom, properties, options);
-}
-exports.lineString = lineString;
-/**
- * Creates a {@link LineString} {@link FeatureCollection} from an Array of LineString coordinates.
- *
- * @name lineStrings
- * @param {Array<Array<Array<number>>>} coordinates an array of LinearRings
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north]
- * associated with the FeatureCollection
- * @param {string|number} [options.id] Identifier associated with the FeatureCollection
- * @returns {FeatureCollection<LineString>} LineString FeatureCollection
- * @example
- * var linestrings = turf.lineStrings([
- *   [[-24, 63], [-23, 60], [-25, 65], [-20, 69]],
- *   [[-14, 43], [-13, 40], [-15, 45], [-10, 49]]
- * ]);
- *
- * //=linestrings
- */
-function lineStrings(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    return featureCollection(coordinates.map(function (coords) {
-        return lineString(coords, properties);
-    }), options);
-}
-exports.lineStrings = lineStrings;
-/**
- * Takes one or more {@link Feature|Features} and creates a {@link FeatureCollection}.
- *
- * @name featureCollection
- * @param {Feature[]} features input features
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {FeatureCollection} FeatureCollection of Features
- * @example
- * var locationA = turf.point([-75.343, 39.984], {name: 'Location A'});
- * var locationB = turf.point([-75.833, 39.284], {name: 'Location B'});
- * var locationC = turf.point([-75.534, 39.123], {name: 'Location C'});
- *
- * var collection = turf.featureCollection([
- *   locationA,
- *   locationB,
- *   locationC
- * ]);
- *
- * //=collection
- */
-function featureCollection(features, options) {
-    if (options === void 0) { options = {}; }
-    var fc = { type: "FeatureCollection" };
-    if (options.id) {
-        fc.id = options.id;
-    }
-    if (options.bbox) {
-        fc.bbox = options.bbox;
-    }
-    fc.features = features;
-    return fc;
-}
-exports.featureCollection = featureCollection;
-/**
- * Creates a {@link Feature<MultiLineString>} based on a
- * coordinate array. Properties can be added optionally.
- *
- * @name multiLineString
- * @param {Array<Array<Array<number>>>} coordinates an array of LineStrings
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {Feature<MultiLineString>} a MultiLineString feature
- * @throws {Error} if no coordinates are passed
- * @example
- * var multiLine = turf.multiLineString([[[0,0],[10,10]]]);
- *
- * //=multiLine
- */
-function multiLineString(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    var geom = {
-        type: "MultiLineString",
-        coordinates: coordinates,
-    };
-    return feature(geom, properties, options);
-}
-exports.multiLineString = multiLineString;
-/**
- * Creates a {@link Feature<MultiPoint>} based on a
- * coordinate array. Properties can be added optionally.
- *
- * @name multiPoint
- * @param {Array<Array<number>>} coordinates an array of Positions
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {Feature<MultiPoint>} a MultiPoint feature
- * @throws {Error} if no coordinates are passed
- * @example
- * var multiPt = turf.multiPoint([[0,0],[10,10]]);
- *
- * //=multiPt
- */
-function multiPoint(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    var geom = {
-        type: "MultiPoint",
-        coordinates: coordinates,
-    };
-    return feature(geom, properties, options);
-}
-exports.multiPoint = multiPoint;
-/**
- * Creates a {@link Feature<MultiPolygon>} based on a
- * coordinate array. Properties can be added optionally.
- *
- * @name multiPolygon
- * @param {Array<Array<Array<Array<number>>>>} coordinates an array of Polygons
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {Feature<MultiPolygon>} a multipolygon feature
- * @throws {Error} if no coordinates are passed
- * @example
- * var multiPoly = turf.multiPolygon([[[[0,0],[0,10],[10,10],[10,0],[0,0]]]]);
- *
- * //=multiPoly
- *
- */
-function multiPolygon(coordinates, properties, options) {
-    if (options === void 0) { options = {}; }
-    var geom = {
-        type: "MultiPolygon",
-        coordinates: coordinates,
-    };
-    return feature(geom, properties, options);
-}
-exports.multiPolygon = multiPolygon;
-/**
- * Creates a {@link Feature<GeometryCollection>} based on a
- * coordinate array. Properties can be added optionally.
- *
- * @name geometryCollection
- * @param {Array<Geometry>} geometries an array of GeoJSON Geometries
- * @param {Object} [properties={}] an Object of key-value pairs to add as properties
- * @param {Object} [options={}] Optional Parameters
- * @param {Array<number>} [options.bbox] Bounding Box Array [west, south, east, north] associated with the Feature
- * @param {string|number} [options.id] Identifier associated with the Feature
- * @returns {Feature<GeometryCollection>} a GeoJSON GeometryCollection Feature
- * @example
- * var pt = turf.geometry("Point", [100, 0]);
- * var line = turf.geometry("LineString", [[101, 0], [102, 1]]);
- * var collection = turf.geometryCollection([pt, line]);
- *
- * // => collection
- */
-function geometryCollection(geometries, properties, options) {
-    if (options === void 0) { options = {}; }
-    var geom = {
-        type: "GeometryCollection",
-        geometries: geometries,
-    };
-    return feature(geom, properties, options);
-}
-exports.geometryCollection = geometryCollection;
-/**
- * Round number to precision
- *
- * @param {number} num Number
- * @param {number} [precision=0] Precision
- * @returns {number} rounded number
- * @example
- * turf.round(120.4321)
- * //=120
- *
- * turf.round(120.4321, 2)
- * //=120.43
- */
-function round(num, precision) {
-    if (precision === void 0) { precision = 0; }
-    if (precision && !(precision >= 0)) {
-        throw new Error("precision must be a positive number");
-    }
-    var multiplier = Math.pow(10, precision || 0);
-    return Math.round(num * multiplier) / multiplier;
-}
-exports.round = round;
-/**
- * Convert a distance measurement (assuming a spherical Earth) from radians to a more friendly unit.
- * Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, centimeters, feet
- *
- * @name radiansToLength
- * @param {number} radians in radians across the sphere
- * @param {string} [units="kilometers"] can be degrees, radians, miles, or kilometers inches, yards, metres,
- * meters, kilometres, kilometers.
- * @returns {number} distance
- */
-function radiansToLength(radians, units) {
-    if (units === void 0) { units = "kilometers"; }
-    var factor = exports.factors[units];
-    if (!factor) {
-        throw new Error(units + " units is invalid");
-    }
-    return radians * factor;
-}
-exports.radiansToLength = radiansToLength;
-/**
- * Convert a distance measurement (assuming a spherical Earth) from a real-world unit into radians
- * Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, centimeters, feet
- *
- * @name lengthToRadians
- * @param {number} distance in real units
- * @param {string} [units="kilometers"] can be degrees, radians, miles, or kilometers inches, yards, metres,
- * meters, kilometres, kilometers.
- * @returns {number} radians
- */
-function lengthToRadians(distance, units) {
-    if (units === void 0) { units = "kilometers"; }
-    var factor = exports.factors[units];
-    if (!factor) {
-        throw new Error(units + " units is invalid");
-    }
-    return distance / factor;
-}
-exports.lengthToRadians = lengthToRadians;
-/**
- * Convert a distance measurement (assuming a spherical Earth) from a real-world unit into degrees
- * Valid units: miles, nauticalmiles, inches, yards, meters, metres, centimeters, kilometres, feet
- *
- * @name lengthToDegrees
- * @param {number} distance in real units
- * @param {string} [units="kilometers"] can be degrees, radians, miles, or kilometers inches, yards, metres,
- * meters, kilometres, kilometers.
- * @returns {number} degrees
- */
-function lengthToDegrees(distance, units) {
-    return radiansToDegrees(lengthToRadians(distance, units));
-}
-exports.lengthToDegrees = lengthToDegrees;
-/**
- * Converts any bearing angle from the north line direction (positive clockwise)
- * and returns an angle between 0-360 degrees (positive clockwise), 0 being the north line
- *
- * @name bearingToAzimuth
- * @param {number} bearing angle, between -180 and +180 degrees
- * @returns {number} angle between 0 and 360 degrees
- */
-function bearingToAzimuth(bearing) {
-    var angle = bearing % 360;
-    if (angle < 0) {
-        angle += 360;
-    }
-    return angle;
-}
-exports.bearingToAzimuth = bearingToAzimuth;
-/**
- * Converts an angle in radians to degrees
- *
- * @name radiansToDegrees
- * @param {number} radians angle in radians
- * @returns {number} degrees between 0 and 360 degrees
- */
-function radiansToDegrees(radians) {
-    var degrees = radians % (2 * Math.PI);
-    return degrees * 180 / Math.PI;
-}
-exports.radiansToDegrees = radiansToDegrees;
-/**
- * Converts an angle in degrees to radians
- *
- * @name degreesToRadians
- * @param {number} degrees angle between 0 and 360 degrees
- * @returns {number} angle in radians
- */
-function degreesToRadians(degrees) {
-    var radians = degrees % 360;
-    return radians * Math.PI / 180;
-}
-exports.degreesToRadians = degreesToRadians;
-/**
- * Converts a length to the requested unit.
- * Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, centimeters, feet
- *
- * @param {number} length to be converted
- * @param {Units} [originalUnit="kilometers"] of the length
- * @param {Units} [finalUnit="kilometers"] returned unit
- * @returns {number} the converted length
- */
-function convertLength(length, originalUnit, finalUnit) {
-    if (originalUnit === void 0) { originalUnit = "kilometers"; }
-    if (finalUnit === void 0) { finalUnit = "kilometers"; }
-    if (!(length >= 0)) {
-        throw new Error("length must be a positive number");
-    }
-    return radiansToLength(lengthToRadians(length, originalUnit), finalUnit);
-}
-exports.convertLength = convertLength;
-/**
- * Converts a area to the requested unit.
- * Valid units: kilometers, kilometres, meters, metres, centimetres, millimeters, acres, miles, yards, feet, inches
- * @param {number} area to be converted
- * @param {Units} [originalUnit="meters"] of the distance
- * @param {Units} [finalUnit="kilometers"] returned unit
- * @returns {number} the converted distance
- */
-function convertArea(area, originalUnit, finalUnit) {
-    if (originalUnit === void 0) { originalUnit = "meters"; }
-    if (finalUnit === void 0) { finalUnit = "kilometers"; }
-    if (!(area >= 0)) {
-        throw new Error("area must be a positive number");
-    }
-    var startFactor = exports.areaFactors[originalUnit];
-    if (!startFactor) {
-        throw new Error("invalid original units");
-    }
-    var finalFactor = exports.areaFactors[finalUnit];
-    if (!finalFactor) {
-        throw new Error("invalid final units");
-    }
-    return (area / startFactor) * finalFactor;
-}
-exports.convertArea = convertArea;
-/**
- * isNumber
- *
- * @param {*} num Number to validate
- * @returns {boolean} true/false
- * @example
- * turf.isNumber(123)
- * //=true
- * turf.isNumber('foo')
- * //=false
- */
-function isNumber(num) {
-    return !isNaN(num) && num !== null && !Array.isArray(num) && !/^\s*$/.test(num);
-}
-exports.isNumber = isNumber;
-/**
- * isObject
- *
- * @param {*} input variable to validate
- * @returns {boolean} true/false
- * @example
- * turf.isObject({elevation: 10})
- * //=true
- * turf.isObject('foo')
- * //=false
- */
-function isObject(input) {
-    return (!!input) && (input.constructor === Object);
-}
-exports.isObject = isObject;
-/**
- * Validate BBox
- *
- * @private
- * @param {Array<number>} bbox BBox to validate
- * @returns {void}
- * @throws Error if BBox is not valid
- * @example
- * validateBBox([-180, -40, 110, 50])
- * //=OK
- * validateBBox([-180, -40])
- * //=Error
- * validateBBox('Foo')
- * //=Error
- * validateBBox(5)
- * //=Error
- * validateBBox(null)
- * //=Error
- * validateBBox(undefined)
- * //=Error
- */
-function validateBBox(bbox) {
-    if (!bbox) {
-        throw new Error("bbox is required");
-    }
-    if (!Array.isArray(bbox)) {
-        throw new Error("bbox must be an Array");
-    }
-    if (bbox.length !== 4 && bbox.length !== 6) {
-        throw new Error("bbox must be an Array of 4 or 6 numbers");
-    }
-    bbox.forEach(function (num) {
-        if (!isNumber(num)) {
-            throw new Error("bbox must only contain numbers");
-        }
-    });
-}
-exports.validateBBox = validateBBox;
-/**
- * Validate Id
- *
- * @private
- * @param {string|number} id Id to validate
- * @returns {void}
- * @throws Error if Id is not valid
- * @example
- * validateId([-180, -40, 110, 50])
- * //=Error
- * validateId([-180, -40])
- * //=Error
- * validateId('Foo')
- * //=OK
- * validateId(5)
- * //=OK
- * validateId(null)
- * //=Error
- * validateId(undefined)
- * //=Error
- */
-function validateId(id) {
-    if (!id) {
-        throw new Error("id is required");
-    }
-    if (["string", "number"].indexOf(typeof id) === -1) {
-        throw new Error("id must be a number or a string");
-    }
-}
-exports.validateId = validateId;
-// Deprecated methods
-function radians2degrees() {
-    throw new Error("method has been renamed to `radiansToDegrees`");
-}
-exports.radians2degrees = radians2degrees;
-function degrees2radians() {
-    throw new Error("method has been renamed to `degreesToRadians`");
-}
-exports.degrees2radians = degrees2radians;
-function distanceToDegrees() {
-    throw new Error("method has been renamed to `lengthToDegrees`");
-}
-exports.distanceToDegrees = distanceToDegrees;
-function distanceToRadians() {
-    throw new Error("method has been renamed to `lengthToRadians`");
-}
-exports.distanceToRadians = distanceToRadians;
-function radiansToDistance() {
-    throw new Error("method has been renamed to `radiansToLength`");
-}
-exports.radiansToDistance = radiansToDistance;
-function bearingToAngle() {
-    throw new Error("method has been renamed to `bearingToAzimuth`");
-}
-exports.bearingToAngle = bearingToAngle;
-function convertDistance() {
-    throw new Error("method has been renamed to `convertLength`");
-}
-exports.convertDistance = convertDistance;
-});
-
-unwrapExports(helpers);
-helpers.earthRadius;
-helpers.factors;
-helpers.unitsFactors;
-helpers.areaFactors;
-helpers.feature;
-helpers.geometry;
-helpers.point;
-helpers.points;
-helpers.polygon;
-helpers.polygons;
-helpers.lineString;
-helpers.lineStrings;
-helpers.featureCollection;
-helpers.multiLineString;
-helpers.multiPoint;
-helpers.multiPolygon;
-helpers.geometryCollection;
-helpers.round;
-helpers.radiansToLength;
-helpers.lengthToRadians;
-helpers.lengthToDegrees;
-helpers.bearingToAzimuth;
-helpers.radiansToDegrees;
-helpers.degreesToRadians;
-helpers.convertLength;
-helpers.convertArea;
-helpers.isNumber;
-helpers.isObject;
-helpers.validateBBox;
-helpers.validateId;
-helpers.radians2degrees;
-helpers.degrees2radians;
-helpers.distanceToDegrees;
-helpers.distanceToRadians;
-helpers.radiansToDistance;
-helpers.bearingToAngle;
-helpers.convertDistance;
-
-var invariant = createCommonjsModule(function (module, exports) {
-Object.defineProperty(exports, "__esModule", { value: true });
-
 /**
  * Unwrap a coordinate from a Point Feature, Geometry or a single coordinate.
  *
@@ -9163,141 +8416,23 @@ function getCoord(coord) {
         throw new Error("coord is required");
     }
     if (!Array.isArray(coord)) {
-        if (coord.type === "Feature" && coord.geometry !== null && coord.geometry.type === "Point") {
+        if (coord.type === "Feature" &&
+            coord.geometry !== null &&
+            coord.geometry.type === "Point") {
             return coord.geometry.coordinates;
         }
         if (coord.type === "Point") {
             return coord.coordinates;
         }
     }
-    if (Array.isArray(coord) && coord.length >= 2 && !Array.isArray(coord[0]) && !Array.isArray(coord[1])) {
+    if (Array.isArray(coord) &&
+        coord.length >= 2 &&
+        !Array.isArray(coord[0]) &&
+        !Array.isArray(coord[1])) {
         return coord;
     }
     throw new Error("coord must be GeoJSON Point or an Array of numbers");
 }
-exports.getCoord = getCoord;
-/**
- * Unwrap coordinates from a Feature, Geometry Object or an Array
- *
- * @name getCoords
- * @param {Array<any>|Geometry|Feature} coords Feature, Geometry Object or an Array
- * @returns {Array<any>} coordinates
- * @example
- * var poly = turf.polygon([[[119.32, -8.7], [119.55, -8.69], [119.51, -8.54], [119.32, -8.7]]]);
- *
- * var coords = turf.getCoords(poly);
- * //= [[[119.32, -8.7], [119.55, -8.69], [119.51, -8.54], [119.32, -8.7]]]
- */
-function getCoords(coords) {
-    if (Array.isArray(coords)) {
-        return coords;
-    }
-    // Feature
-    if (coords.type === "Feature") {
-        if (coords.geometry !== null) {
-            return coords.geometry.coordinates;
-        }
-    }
-    else {
-        // Geometry
-        if (coords.coordinates) {
-            return coords.coordinates;
-        }
-    }
-    throw new Error("coords must be GeoJSON Feature, Geometry Object or an Array");
-}
-exports.getCoords = getCoords;
-/**
- * Checks if coordinates contains a number
- *
- * @name containsNumber
- * @param {Array<any>} coordinates GeoJSON Coordinates
- * @returns {boolean} true if Array contains a number
- */
-function containsNumber(coordinates) {
-    if (coordinates.length > 1 && helpers.isNumber(coordinates[0]) && helpers.isNumber(coordinates[1])) {
-        return true;
-    }
-    if (Array.isArray(coordinates[0]) && coordinates[0].length) {
-        return containsNumber(coordinates[0]);
-    }
-    throw new Error("coordinates must only contain numbers");
-}
-exports.containsNumber = containsNumber;
-/**
- * Enforce expectations about types of GeoJSON objects for Turf.
- *
- * @name geojsonType
- * @param {GeoJSON} value any GeoJSON object
- * @param {string} type expected GeoJSON type
- * @param {string} name name of calling function
- * @throws {Error} if value is not the expected type.
- */
-function geojsonType(value, type, name) {
-    if (!type || !name) {
-        throw new Error("type and name required");
-    }
-    if (!value || value.type !== type) {
-        throw new Error("Invalid input to " + name + ": must be a " + type + ", given " + value.type);
-    }
-}
-exports.geojsonType = geojsonType;
-/**
- * Enforce expectations about types of {@link Feature} inputs for Turf.
- * Internally this uses {@link geojsonType} to judge geometry types.
- *
- * @name featureOf
- * @param {Feature} feature a feature with an expected geometry type
- * @param {string} type expected GeoJSON type
- * @param {string} name name of calling function
- * @throws {Error} error if value is not the expected type.
- */
-function featureOf(feature, type, name) {
-    if (!feature) {
-        throw new Error("No feature passed");
-    }
-    if (!name) {
-        throw new Error(".featureOf() requires a name");
-    }
-    if (!feature || feature.type !== "Feature" || !feature.geometry) {
-        throw new Error("Invalid input to " + name + ", Feature with geometry required");
-    }
-    if (!feature.geometry || feature.geometry.type !== type) {
-        throw new Error("Invalid input to " + name + ": must be a " + type + ", given " + feature.geometry.type);
-    }
-}
-exports.featureOf = featureOf;
-/**
- * Enforce expectations about types of {@link FeatureCollection} inputs for Turf.
- * Internally this uses {@link geojsonType} to judge geometry types.
- *
- * @name collectionOf
- * @param {FeatureCollection} featureCollection a FeatureCollection for which features will be judged
- * @param {string} type expected GeoJSON type
- * @param {string} name name of calling function
- * @throws {Error} if value is not the expected type.
- */
-function collectionOf(featureCollection, type, name) {
-    if (!featureCollection) {
-        throw new Error("No featureCollection passed");
-    }
-    if (!name) {
-        throw new Error(".collectionOf() requires a name");
-    }
-    if (!featureCollection || featureCollection.type !== "FeatureCollection") {
-        throw new Error("Invalid input to " + name + ", FeatureCollection required");
-    }
-    for (var _i = 0, _a = featureCollection.features; _i < _a.length; _i++) {
-        var feature = _a[_i];
-        if (!feature || feature.type !== "Feature" || !feature.geometry) {
-            throw new Error("Invalid input to " + name + ", Feature with geometry required");
-        }
-        if (!feature.geometry || feature.geometry.type !== type) {
-            throw new Error("Invalid input to " + name + ": must be a " + type + ", given " + feature.geometry.type);
-        }
-    }
-}
-exports.collectionOf = collectionOf;
 /**
  * Get Geometry from Feature or Geometry Object
  *
@@ -9322,52 +8457,6 @@ function getGeom(geojson) {
     }
     return geojson;
 }
-exports.getGeom = getGeom;
-/**
- * Get GeoJSON object's type, Geometry type is prioritize.
- *
- * @param {GeoJSON} geojson GeoJSON object
- * @param {string} [name="geojson"] name of the variable to display in error message
- * @returns {string} GeoJSON type
- * @example
- * var point = {
- *   "type": "Feature",
- *   "properties": {},
- *   "geometry": {
- *     "type": "Point",
- *     "coordinates": [110, 40]
- *   }
- * }
- * var geom = turf.getType(point)
- * //="Point"
- */
-function getType(geojson, name) {
-    if (geojson.type === "FeatureCollection") {
-        return "FeatureCollection";
-    }
-    if (geojson.type === "GeometryCollection") {
-        return "GeometryCollection";
-    }
-    if (geojson.type === "Feature" && geojson.geometry !== null) {
-        return geojson.geometry.type;
-    }
-    return geojson.type;
-}
-exports.getType = getType;
-});
-
-unwrapExports(invariant);
-invariant.getCoord;
-invariant.getCoords;
-invariant.containsNumber;
-invariant.geojsonType;
-invariant.featureOf;
-invariant.collectionOf;
-invariant.getGeom;
-invariant.getType;
-
-var booleanPointInPolygon_1 = createCommonjsModule(function (module, exports) {
-Object.defineProperty(exports, "__esModule", { value: true });
 
 // http://en.wikipedia.org/wiki/Even%E2%80%93odd_rule
 // modified from: https://github.com/substack/point-in-polygon/blob/master/index.js
@@ -9405,8 +8494,8 @@ function booleanPointInPolygon(point, polygon, options) {
     if (!polygon) {
         throw new Error("polygon is required");
     }
-    var pt = invariant.getCoord(point);
-    var geom = invariant.getGeom(polygon);
+    var pt = getCoord(point);
+    var geom = getGeom(polygon);
     var type = geom.type;
     var bbox = polygon.bbox;
     var polys = geom.coordinates;
@@ -9438,7 +8527,6 @@ function booleanPointInPolygon(point, polygon, options) {
     }
     return insidePoly;
 }
-exports.default = booleanPointInPolygon;
 /**
  * inRing
  *
@@ -9450,7 +8538,8 @@ exports.default = booleanPointInPolygon;
  */
 function inRing(pt, ring, ignoreBoundary) {
     var isInside = false;
-    if (ring[0][0] === ring[ring.length - 1][0] && ring[0][1] === ring[ring.length - 1][1]) {
+    if (ring[0][0] === ring[ring.length - 1][0] &&
+        ring[0][1] === ring[ring.length - 1][1]) {
         ring = ring.slice(0, ring.length - 1);
     }
     for (var i = 0, j = ring.length - 1; i < ring.length; j = i++) {
@@ -9458,13 +8547,14 @@ function inRing(pt, ring, ignoreBoundary) {
         var yi = ring[i][1];
         var xj = ring[j][0];
         var yj = ring[j][1];
-        var onBoundary = (pt[1] * (xi - xj) + yi * (xj - pt[0]) + yj * (pt[0] - xi) === 0) &&
-            ((xi - pt[0]) * (xj - pt[0]) <= 0) && ((yi - pt[1]) * (yj - pt[1]) <= 0);
+        var onBoundary = pt[1] * (xi - xj) + yi * (xj - pt[0]) + yj * (pt[0] - xi) === 0 &&
+            (xi - pt[0]) * (xj - pt[0]) <= 0 &&
+            (yi - pt[1]) * (yj - pt[1]) <= 0;
         if (onBoundary) {
             return !ignoreBoundary;
         }
-        var intersect = ((yi > pt[1]) !== (yj > pt[1])) &&
-            (pt[0] < (xj - xi) * (pt[1] - yi) / (yj - yi) + xi);
+        var intersect = yi > pt[1] !== yj > pt[1] &&
+            pt[0] < ((xj - xi) * (pt[1] - yi)) / (yj - yi) + xi;
         if (intersect) {
             isInside = !isInside;
         }
@@ -9480,14 +8570,8 @@ function inRing(pt, ring, ignoreBoundary) {
  * @returns {boolean} true/false if point is inside BBox
  */
 function inBBox(pt, bbox) {
-    return bbox[0] <= pt[0] &&
-        bbox[1] <= pt[1] &&
-        bbox[2] >= pt[0] &&
-        bbox[3] >= pt[1];
+    return (bbox[0] <= pt[0] && bbox[1] <= pt[1] && bbox[2] >= pt[0] && bbox[3] >= pt[1]);
 }
-});
-
-var booleanPointInPolygon = unwrapExports(booleanPointInPolygon_1);
 
 function initSelector(sources, projection) {
   const tileSize = 512; // TODO: don't assume this
@@ -9544,7 +8628,7 @@ function measureDistance(pt, geometry) {
   }
 }
 
-function init$2$1(userParams) {
+function init$3(userParams) {
   const params = setParams$1(userParams);
 
   // Set up dummy API
@@ -9603,7 +8687,7 @@ function initMap(params) {
   const { context, width, height, style, mapboxToken } = params;
   const framebuffer = context.initFramebuffer({ width, height });
 
-  return init$2$1({ context, framebuffer, style, mapboxToken, units: "radians" })
+  return init$3({ context, framebuffer, style, mapboxToken, units: "radians" })
     .promise.then(api => setup$1(api, context, framebuffer.sampler))
     .catch(console.log);
 }
@@ -11665,11 +10749,10 @@ function initMarkers(globe, container) {
 }
 
 function initGlobe(userParams) {
-  const params = setParams$2(userParams);
+  const params = setParams$3(userParams);
 
   return initMap(params)
-    .then(map => setup(map, params))
-    .catch(console.log);
+    .then(map => setup(map, params));
 }
 
 function setup(map, params) {

--- a/examples/geojson/index.html
+++ b/examples/geojson/index.html
@@ -40,6 +40,6 @@
 
         requestID = requestAnimationFrame(animate);
       }
-    });
+    }).catch(console.log);
   </script>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "satellite-view": "^2.0.1",
-        "spinning-ball": "^0.2.3",
+        "spinning-ball": "^0.2.4",
         "tile-setter": "^0.0.6",
         "yawgl": "^0.3.1"
       },
@@ -325,13 +325,13 @@
       }
     },
     "node_modules/spinning-ball": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.2.3.tgz",
-      "integrity": "sha512-3pbhFTRaFN0f41OMxylhnsD7ePEohyAzwcOUjs+4LPQNp5+xfGnx32mSVYrueTDnQM7zoH/BwvtRUMTRpUuLMw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.2.4.tgz",
+      "integrity": "sha512-QL/x9L5WVqo7NJCljF5P/fnUGxqtqR0+eRiz2x0WZRAAiq+oiDQ/gkjHK5Q1ppgCaBZuhGz33VZb+6Xcy3CZ9A==",
       "dependencies": {
         "gl-matrix": "^3.1.0",
         "touch-sampler": "0.0.1",
-        "yawgl": "github:GlobeletJS/yawgl"
+        "yawgl": "^0.3.1"
       }
     },
     "node_modules/tile-gl": {
@@ -646,13 +646,13 @@
       }
     },
     "spinning-ball": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.2.3.tgz",
-      "integrity": "sha512-3pbhFTRaFN0f41OMxylhnsD7ePEohyAzwcOUjs+4LPQNp5+xfGnx32mSVYrueTDnQM7zoH/BwvtRUMTRpUuLMw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.2.4.tgz",
+      "integrity": "sha512-QL/x9L5WVqo7NJCljF5P/fnUGxqtqR0+eRiz2x0WZRAAiq+oiDQ/gkjHK5Q1ppgCaBZuhGz33VZb+6Xcy3CZ9A==",
       "requires": {
         "gl-matrix": "^3.1.0",
         "touch-sampler": "0.0.1",
-        "yawgl": "github:GlobeletJS/yawgl"
+        "yawgl": "^0.3.1"
       }
     },
     "tile-gl": {
@@ -723,7 +723,7 @@
     },
     "yawgl": {
       "version": "git+ssh://git@github.com/GlobeletJS/yawgl.git#3d5e35b5947280dfa25acb2e5cd0c5442da629b9",
-      "from": "yawgl@0.3.1"
+      "from": "yawgl@^0.3.1"
     },
     "zero-timeout": {
       "version": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "satellite-view": "^2.0.0",
+        "satellite-view": "^2.0.1",
         "spinning-ball": "^0.2.3",
-        "tile-setter": "^0.0.5",
-        "yawgl": "^0.3.0"
+        "tile-setter": "^0.0.6",
+        "yawgl": "^0.3.1"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^11.2.1",
-        "rollup": "^2.51.2"
+        "@rollup/plugin-node-resolve": "^13.0.0",
+        "rollup": "^2.52.7"
       }
     },
     "node_modules/@rollup/plugin-json": {
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
-      "integrity": "sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
+      "integrity": "sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
@@ -49,7 +49,7 @@
         "node": ">= 10.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
+        "rollup": "^2.42.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -76,9 +76,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
+      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.51.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.51.2.tgz",
-      "integrity": "sha512-ReV2eGEadA7hmXSzjxdDKs10neqH2QURf2RxJ6ayAlq93ugy6qIvXMmbc5cWMGCDh1h5T4thuWO1e2VNbMq8FA==",
+      "version": "2.52.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.7.tgz",
+      "integrity": "sha512-55cSH4CCU6MaPr9TAOyrIC+7qFCHscL7tkNsm1MBfIJRRqRbCEY0mmeFn4Wg8FKsHtEH8r389Fz38r/o+kgXLg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -305,18 +305,18 @@
         "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/satellite-view": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.0.0.tgz",
-      "integrity": "sha512-t3cZnxcOagnkz9AJf99iwKvuNRdzsXsTmrkr7B34fmwkjraTVYr4lH9j5t4xEqibg1eUYcrYz7hrWY1YIAX2Jw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.0.1.tgz",
+      "integrity": "sha512-wQjAeFEY+0vJcSTrhQA0OQNMpp9HlhKpySKbNHLjiTcrrDYXaoWfCV8N+vf0/0TE5JQqtf1f12uDfmM2oEBG+A=="
     },
     "node_modules/sdf-manager": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/sdf-manager/-/sdf-manager-0.0.6.tgz",
-      "integrity": "sha512-K/9z0WruGC7RywHZRu3wfqUXh7GQnDhcnqi/ap+pcTMICSfCtyvJ0Xkbyj4++vilbdabxBGv8nyr0OQej2lMPA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sdf-manager/-/sdf-manager-0.0.7.tgz",
+      "integrity": "sha512-e7IJgejEEFyq2jm7b/mQTQ0oAYBhX2PMMNe1cWIBDmN2EsYqtuVkqkl07McMg6afAWaqM1XG4kjM3wv6rqCFbQ==",
       "dependencies": {
         "potpack": "^1.0.1"
       },
@@ -335,35 +335,34 @@
       }
     },
     "node_modules/tile-gl": {
-      "version": "0.0.7",
-      "resolved": "git+ssh://git@github.com/GlobeletJS/tile-gl.git#88fba190729893472473e87b1ac9ef53ef026615",
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/GlobeletJS/tile-gl.git#95775ec70aebfa438336b86d0dd796824fc88df3",
       "license": "MIT",
       "dependencies": {
         "earcut": "^2.2.2",
-        "gl-matrix": "^3.3.0",
-        "tile-labeler": "github:GlobeletJS/tile-labeler"
+        "tile-labeler": "^0.2.0"
       }
     },
     "node_modules/tile-labeler": {
-      "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/GlobeletJS/tile-labeler.git#68c740eeafd2fea024a93eb8c6f124ad0f951c49",
-      "license": "MIT",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.2.0.tgz",
+      "integrity": "sha512-IfSvc3OA3WYGg3m2vuQlPO5Lom9RWMcWlFPHauPP6ZmkB2KqCqbv8pONMnNoMqh+YJ2gSBztFPVrut1S31WRsQ==",
       "dependencies": {
-        "sdf-manager": "0.0.6"
+        "sdf-manager": "^0.0.7"
       }
     },
     "node_modules/tile-mixer": {
-      "version": "0.0.9",
-      "resolved": "git+ssh://git@github.com/GlobeletJS/tile-mixer.git#d8a7ca6e89fc726f3c298793eac34fad12ed5376",
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/GlobeletJS/tile-mixer.git#ac533d17c1dff4086cfe8d7908f2262159111224",
       "license": "MIT",
       "dependencies": {
         "chunked-queue": "^0.1.2",
         "geojson-vt": "^3.2.1",
         "pbf": "^3.2.1",
         "rbush": "^3.0.1",
-        "tile-gl": "github:GlobeletJS/tile-gl",
-        "tile-labeler": "github:GlobeletJS/tile-labeler",
-        "tile-stencil": "^0.3.1",
+        "tile-gl": "^0.1.0",
+        "tile-labeler": "^0.2.0",
+        "tile-stencil": "^0.4.2",
         "vector-tile-esm": "^2.1.2"
       }
     },
@@ -373,22 +372,22 @@
       "integrity": "sha512-+OZHBM/ZmOop3avd+UL3+4ZKIHfna/wDZGx9mNybPsogu3qNK5PBb9yB8KLNxqcH+olNL7V1vP+nYikIm+CNqA=="
     },
     "node_modules/tile-setter": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.0.5.tgz",
-      "integrity": "sha512-CPj86WQokj2YTvlQeCztRGhs3AoxjLo7eF1I2pwh6aio283a3y6m+ISI7f7+zFOf2ZfSV1Y6URCw8Ec+i4T6ew==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.0.6.tgz",
+      "integrity": "sha512-Yw7Y/8oKKm0D1MyNknsgZGtTVpydBQ8oJ6oQAmYjwXOLXGXZVWtyOjDeL+7LVAv0JWK0LMq/9JmkWRtFBzk8lw==",
       "dependencies": {
         "chunked-queue": "^0.1.2",
         "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-gl": "github:GlobeletJS/tile-gl",
-        "tile-mixer": "github:GlobeletJS/tile-mixer",
+        "tile-gl": "^0.1.0",
+        "tile-mixer": "^0.1.0",
         "tile-rack": "^1.0.2",
-        "tile-stencil": "^0.3.1"
+        "tile-stencil": "^0.4.2"
       }
     },
     "node_modules/tile-stencil": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.3.1.tgz",
-      "integrity": "sha512-8WsDE8/+XwoU4Hoo5xKEbFcMi2vCUHgtfK2YxtPSlWJjO20kA2gV0OX6gkffOD+dwxtpb3yGGKOFp1VoPViW4A==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.2.tgz",
+      "integrity": "sha512-7iM1WYbZ9zX3yW2mR7Ru89dabRyiMkvZUss0rJgIQXu6B8Qx56L4IblTfLdlJBKJ8bOZs4OtbSAbr8d40s2pjQ==",
       "dependencies": {
         "d3-color": "^1.4.1"
       }
@@ -404,8 +403,8 @@
       "integrity": "sha512-l0doLJsMkZz5DWEewK9oh5Dp3iqO8lgKcpy+IxasckrQ/AjyyZxZCN1NRLZRROdjHt8aqf1gMuwq8e6Mi9f5Pw=="
     },
     "node_modules/yawgl": {
-      "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/GlobeletJS/yawgl.git#d03f2c95cd073530bae7a4543ee964a74c01c839",
+      "version": "0.3.1",
+      "resolved": "git+ssh://git@github.com/GlobeletJS/yawgl.git#3d5e35b5947280dfa25acb2e5cd0c5442da629b9",
       "license": "MIT"
     },
     "node_modules/zero-timeout": {
@@ -425,9 +424,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
-      "integrity": "sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
+      "integrity": "sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -456,9 +455,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
+      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==",
       "dev": true
     },
     "@types/resolve": {
@@ -625,23 +624,23 @@
       }
     },
     "rollup": {
-      "version": "2.51.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.51.2.tgz",
-      "integrity": "sha512-ReV2eGEadA7hmXSzjxdDKs10neqH2QURf2RxJ6ayAlq93ugy6qIvXMmbc5cWMGCDh1h5T4thuWO1e2VNbMq8FA==",
+      "version": "2.52.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.7.tgz",
+      "integrity": "sha512-55cSH4CCU6MaPr9TAOyrIC+7qFCHscL7tkNsm1MBfIJRRqRbCEY0mmeFn4Wg8FKsHtEH8r389Fz38r/o+kgXLg==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "satellite-view": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.0.0.tgz",
-      "integrity": "sha512-t3cZnxcOagnkz9AJf99iwKvuNRdzsXsTmrkr7B34fmwkjraTVYr4lH9j5t4xEqibg1eUYcrYz7hrWY1YIAX2Jw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.0.1.tgz",
+      "integrity": "sha512-wQjAeFEY+0vJcSTrhQA0OQNMpp9HlhKpySKbNHLjiTcrrDYXaoWfCV8N+vf0/0TE5JQqtf1f12uDfmM2oEBG+A=="
     },
     "sdf-manager": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/sdf-manager/-/sdf-manager-0.0.6.tgz",
-      "integrity": "sha512-K/9z0WruGC7RywHZRu3wfqUXh7GQnDhcnqi/ap+pcTMICSfCtyvJ0Xkbyj4++vilbdabxBGv8nyr0OQej2lMPA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sdf-manager/-/sdf-manager-0.0.7.tgz",
+      "integrity": "sha512-e7IJgejEEFyq2jm7b/mQTQ0oAYBhX2PMMNe1cWIBDmN2EsYqtuVkqkl07McMg6afAWaqM1XG4kjM3wv6rqCFbQ==",
       "requires": {
         "potpack": "^1.0.1"
       }
@@ -657,32 +656,32 @@
       }
     },
     "tile-gl": {
-      "version": "git+ssh://git@github.com/GlobeletJS/tile-gl.git#88fba190729893472473e87b1ac9ef53ef026615",
-      "from": "tile-gl@github:GlobeletJS/tile-gl",
+      "version": "git+ssh://git@github.com/GlobeletJS/tile-gl.git#95775ec70aebfa438336b86d0dd796824fc88df3",
+      "from": "tile-gl@^0.1.0",
       "requires": {
         "earcut": "^2.2.2",
-        "gl-matrix": "^3.3.0",
-        "tile-labeler": "github:GlobeletJS/tile-labeler"
+        "tile-labeler": "^0.2.0"
       }
     },
     "tile-labeler": {
-      "version": "git+ssh://git@github.com/GlobeletJS/tile-labeler.git#68c740eeafd2fea024a93eb8c6f124ad0f951c49",
-      "from": "tile-labeler@github:GlobeletJS/tile-labeler",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.2.0.tgz",
+      "integrity": "sha512-IfSvc3OA3WYGg3m2vuQlPO5Lom9RWMcWlFPHauPP6ZmkB2KqCqbv8pONMnNoMqh+YJ2gSBztFPVrut1S31WRsQ==",
       "requires": {
-        "sdf-manager": "0.0.6"
+        "sdf-manager": "^0.0.7"
       }
     },
     "tile-mixer": {
-      "version": "git+ssh://git@github.com/GlobeletJS/tile-mixer.git#d8a7ca6e89fc726f3c298793eac34fad12ed5376",
-      "from": "tile-mixer@github:GlobeletJS/tile-mixer",
+      "version": "git+ssh://git@github.com/GlobeletJS/tile-mixer.git#ac533d17c1dff4086cfe8d7908f2262159111224",
+      "from": "tile-mixer@^0.1.0",
       "requires": {
         "chunked-queue": "^0.1.2",
         "geojson-vt": "^3.2.1",
         "pbf": "^3.2.1",
         "rbush": "^3.0.1",
-        "tile-gl": "github:GlobeletJS/tile-gl",
-        "tile-labeler": "github:GlobeletJS/tile-labeler",
-        "tile-stencil": "^0.3.1",
+        "tile-gl": "^0.1.0",
+        "tile-labeler": "^0.2.0",
+        "tile-stencil": "^0.4.2",
         "vector-tile-esm": "^2.1.2"
       }
     },
@@ -692,22 +691,22 @@
       "integrity": "sha512-+OZHBM/ZmOop3avd+UL3+4ZKIHfna/wDZGx9mNybPsogu3qNK5PBb9yB8KLNxqcH+olNL7V1vP+nYikIm+CNqA=="
     },
     "tile-setter": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.0.5.tgz",
-      "integrity": "sha512-CPj86WQokj2YTvlQeCztRGhs3AoxjLo7eF1I2pwh6aio283a3y6m+ISI7f7+zFOf2ZfSV1Y6URCw8Ec+i4T6ew==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.0.6.tgz",
+      "integrity": "sha512-Yw7Y/8oKKm0D1MyNknsgZGtTVpydBQ8oJ6oQAmYjwXOLXGXZVWtyOjDeL+7LVAv0JWK0LMq/9JmkWRtFBzk8lw==",
       "requires": {
         "chunked-queue": "^0.1.2",
         "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-gl": "github:GlobeletJS/tile-gl",
-        "tile-mixer": "github:GlobeletJS/tile-mixer",
+        "tile-gl": "^0.1.0",
+        "tile-mixer": "^0.1.0",
         "tile-rack": "^1.0.2",
-        "tile-stencil": "^0.3.1"
+        "tile-stencil": "^0.4.2"
       }
     },
     "tile-stencil": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.3.1.tgz",
-      "integrity": "sha512-8WsDE8/+XwoU4Hoo5xKEbFcMi2vCUHgtfK2YxtPSlWJjO20kA2gV0OX6gkffOD+dwxtpb3yGGKOFp1VoPViW4A==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.2.tgz",
+      "integrity": "sha512-7iM1WYbZ9zX3yW2mR7Ru89dabRyiMkvZUss0rJgIQXu6B8Qx56L4IblTfLdlJBKJ8bOZs4OtbSAbr8d40s2pjQ==",
       "requires": {
         "d3-color": "^1.4.1"
       }
@@ -723,8 +722,8 @@
       "integrity": "sha512-l0doLJsMkZz5DWEewK9oh5Dp3iqO8lgKcpy+IxasckrQ/AjyyZxZCN1NRLZRROdjHt8aqf1gMuwq8e6Mi9f5Pw=="
     },
     "yawgl": {
-      "version": "git+ssh://git@github.com/GlobeletJS/yawgl.git#d03f2c95cd073530bae7a4543ee964a74c01c839",
-      "from": "yawgl@^0.3.0"
+      "version": "git+ssh://git@github.com/GlobeletJS/yawgl.git#3d5e35b5947280dfa25acb2e5cd0c5442da629b9",
+      "from": "yawgl@0.3.1"
     },
     "zero-timeout": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   "homepage": "https://globeletjs.org",
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^11.2.1",
-    "rollup": "^2.51.2"
+    "@rollup/plugin-node-resolve": "^13.0.0",
+    "rollup": "^2.52.7"
   },
   "dependencies": {
-    "satellite-view": "^2.0.0",
+    "satellite-view": "^2.0.1",
     "spinning-ball": "^0.2.3",
-    "tile-setter": "^0.0.5",
-    "yawgl": "^0.3.0"
+    "tile-setter": "^0.0.6",
+    "yawgl": "^0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "satellite-view": "^2.0.1",
-    "spinning-ball": "^0.2.3",
+    "spinning-ball": "^0.2.4",
     "tile-setter": "^0.0.6",
     "yawgl": "^0.3.1"
   }

--- a/src/main.js
+++ b/src/main.js
@@ -10,8 +10,7 @@ export function initGlobe(userParams) {
   const params = setParams(userParams);
 
   return initMap(params)
-    .then(map => setup(map, params))
-    .catch(console.log);
+    .then(map => setup(map, params));
 }
 
 function setup(map, params) {


### PR DESCRIPTION
- README.md: Add (incomplete) list of unsupported features
- package.json: Update tile-stencil to improve error messages for
  style loading, and allow rendering of styles for which one source
  or sprite is not accessible
- src/main.js: Do not .catch errors on init--leave this to the
  example code

This should address the last point in #1. If there are problems with the user's style document, the error messages will now be more explanatory. And the README points to the limitations in the dependent modules, to clarify what subset of the specification is supported.