### PR TITLE
Units of marker, camera, and cursor positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,5 +174,6 @@ supported. Or better yet, try adding them yourself! See the
 [contributing guidelines](./CONTRIBUTING.md) for how to get started.
 
 
+[tile-setter]: https://github.com/GlobeletJS/tile-setter
 [tile-stencil-limitations]: https://github.com/GlobeletJS/tile-stencil#un-supported-features
 [tile-gl-todo]: https://github.com/GlobeletJS/tile-gl#todo

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ globePromise.then(globeAPI => {
   velocity and cursor inputs since the last update. Input is a timestamp in
   milliseconds as supplied by [requestAnimationFrame][]. For animation loops
   managed by the parent program
-- `cameraPos`: Link to the camera position as reported by [spinning-ball][] 
-- `cursorPos`: Link to the cursor position as reported by [spinning-ball][]
+- `cameraPos()`: Returns the camera position as reported by [spinning-ball][] 
+- `cursorPos()`: Returns the cursor position as reported by [spinning-ball][]
 - `isMoving()`: Returns the value of the camMoving flag in [spinning-ball][]
-- `wasTapped`: Returns the value of the wasTapped flag in [spinning-ball][]
+- `wasTapped()`: Returns the value of the wasTapped flag in [spinning-ball][]
 - `addMarker(options)`: Adds a marker to the globe. See markers section below
 - `removeMarker(marker)`: Removes a given marker from memory and from the DOM
 - `destroy()`: Clears memory / removes elements from document

--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ where `options` is an object with the following properties:
 - `type`: The type of marker. If `type === "spot"`, the marker element will
   default to a circular SVG; otherwise it defaults to a standard placemarker 
   SVG
-- `lonLat`: A 2-element Array containing longitude and latitude of the desired
-  marker position, in radians
+- `position`: An Array containing longitude and latitude of the desired
+  marker position, in degrees, and (optionally) the altitude in kilometers
 
 The returned `marker` object has the following properties:
 - `element`: Back-link to the HTML element used to represent the marker
   position
-- `lonLat`: A Float64Array containing the longitude and latitude of the marker
-  position, in radians
+- `position`: A Float64Array containing the longitude and latitude of the marker
+  position, in degrees, and its altitude in kilometers
 - `screenPos`: A 2-element Array containing the current screen position of the
   marker, in pixels from top left
 

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -150,7 +150,7 @@ var globeletjs = (function (exports) {
       .filter(info => info !== undefined);
 
     const textureTypes = [gl.SAMPLER_2D, gl.SAMPLER_CUBE];
-    var textureUnit = 0;
+    let textureUnit = 0;
 
     return uniformInfo.reduce((d, info) => {
       const { name, type, size } = info;
@@ -225,7 +225,7 @@ var globeletjs = (function (exports) {
     gl.linkProgram(program);
 
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-      fail$2("Unable to link the program", gl.getProgramInfoLog(program));
+      fail$3("Unable to link the program", gl.getProgramInfoLog(program));
     }
 
     const { constantSetters, constructVao } = initAttributes(gl, program);
@@ -246,13 +246,13 @@ var globeletjs = (function (exports) {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
       const log = gl.getShaderInfoLog(shader);
       gl.deleteShader(shader);
-      fail$2("An error occured compiling the shader", log);
+      fail$3("An error occured compiling the shader", log);
     }
 
     return shader;
   }
 
-  function fail$2(msg, log) {
+  function fail$3(msg, log) {
     throw Error("yawgl.initProgram: " + msg + ":\n" + log);
   }
 
@@ -464,7 +464,7 @@ var globeletjs = (function (exports) {
     }
   }
 
-  var version = "0.0.1";
+  var version = "0.0.2";
 
   var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="sprite">
   <!--Default image for favicon-->
@@ -567,7 +567,7 @@ var globeletjs = (function (exports) {
   // Maximum latitude for Web Mercator: 85.0113 degrees. Beware rounding!
   const maxMercLat$1 = 2.0 * Math.atan( Math.exp(Math.PI) ) - Math.PI / 2.0;
   const clipLat = (lat) => Math.min(Math.max(-maxMercLat$1, lat), maxMercLat$1);
-  const degrees$1 = 180.0 / Math.PI;
+  const degrees = 180.0 / Math.PI;
 
   function getProjection(units) {
     switch (units) {
@@ -585,9 +585,9 @@ var globeletjs = (function (exports) {
         };
       case "degrees":
         return {
-          forward: (pt) => forward(pt.map(c => c / degrees$1)),
-          inverse: (pt) => inverse(pt).map(c => c * degrees$1),
-          scale: (pt) => scale$1(pt.map(c => c / degrees$1)),
+          forward: (pt) => forward(pt.map(c => c / degrees)),
+          inverse: (pt) => inverse(pt).map(c => c * degrees),
+          scale: (pt) => scale$1(pt.map(c => c / degrees)),
         };
       default:
         throw Error("getProjection: unknown units = " + units);
@@ -1399,7 +1399,7 @@ void main() {
     };
   }
 
-  function setParams$1(userParams) {
+  function setParams$1$1(userParams) {
     const gl = userParams.context.gl;
     if (!(gl instanceof WebGLRenderingContext)) {
       fail$1("no valid WebGL context");
@@ -2589,18 +2589,18 @@ void main() {
     } = userParams;
 
     // Confirm supplied styles are all vector layers reading from the same source
-    if (!layers || !layers.length) fail("no valid array of style layers!");
+    if (!layers || !layers.length) fail$2("no valid array of style layers!");
 
     const allVectors = layers.every( l => vectorTypes.includes(l.type) );
-    if (!allVectors) fail("not all layers are vector types!");
+    if (!allVectors) fail$2("not all layers are vector types!");
 
     const sameSource = layers.every( l => l.source === layers[0].source );
-    if (!sameSource) fail("supplied layers use different sources!");
+    if (!sameSource) fail$2("supplied layers use different sources!");
 
-    if (!source) fail("parameters.source is required!");
+    if (!source) fail$2("parameters.source is required!");
 
     if (source.type === "vector" && !(source.tiles && source.tiles.length)) {
-      fail("no valid vector tile endpoints!");
+      fail$2("no valid vector tile endpoints!");
     }
 
     return {
@@ -2614,7 +2614,7 @@ void main() {
     };
   }
 
-  function fail(message) {
+  function fail$2(message) {
     throw Error("ERROR in tile-mixer: " + message);
   }
 
@@ -8643,7 +8643,7 @@ function sendTile(id, tile) {
   }
 
   function init$3(userParams) {
-    const params = setParams$1(userParams);
+    const params = setParams$1$1(userParams);
 
     // Set up dummy API
     const api = {
@@ -8702,8 +8702,7 @@ function sendTile(id, tile) {
     const framebuffer = context.initFramebuffer({ width, height });
 
     return init$3({ context, framebuffer, style, mapboxToken, units: "radians" })
-      .promise.then(api => setup$1(api, context, framebuffer.sampler))
-      .catch(console.log);
+      .promise.then(api => setup$1(api, context, framebuffer.sampler));
   }
 
   function setup$1(api, context, sampler) {
@@ -8733,7 +8732,7 @@ function sendTile(id, tile) {
       const k = 1.0 / dMap;
       const zoom = Math.log2(k) - 9;
 
-      api.setCenterZoom(camPos, zoom, "radians");
+      api.setCenterZoom(camPos, zoom);
       loadStatus = api.draw();
 
       texture.scale.set(api.getScale());
@@ -8743,7 +8742,7 @@ function sendTile(id, tile) {
     }
 
     function select(layer, point, radius) {
-      return api.select({ layer, point, radius, units: "radians" });
+      return api.select({ layer, point, radius });
     }
   }
 
@@ -8752,8 +8751,8 @@ function sendTile(id, tile) {
     // fieldOfView is the vertical view angle range in degrees (floating point)
 
     // Compute values for transformation between the 3D world and the 2D porthole
-    var portRect, width, height, aspect;
-    var tanFOV = Math.tan(fieldOfView * Math.PI / 180.0 / 2.0);
+    let portRect, width, height, aspect;
+    const tanFOV = Math.tan(fieldOfView * Math.PI / 180.0 / 2.0);
     const maxRay = [];
 
     computeRayParams(); // Set initial values
@@ -8800,218 +8799,20 @@ function sendTile(id, tile) {
       // right pixel -- they are one more than the clientX/Y values.
       // Thus the number of pixels in the box is given by
       //    porthole.clientWidth = rect.right - rect.left  (NO +1 !!)
-      var x = clientX - portRect.left;
-      var y = portRect.bottom - clientY - 1; // Flip sign to make +y upward
+      const x = clientX - portRect.left;
+      const y = portRect.bottom - clientY - 1; // Flip sign to make +y upward
 
       // Normalized distances from center of box. We normalize by pixel DISTANCE
       // rather than pixel count, to ensure we get -1 and +1 at the ends.
       // (Confirm by considering the 2x2 case)
-      var xratio = 2 * x / (width - 1) - 1;
-      var yratio = 2 * y / (height - 1) - 1;
+      const xratio = 2 * x / (width - 1) - 1;
+      const yratio = 2 * y / (height - 1) - 1;
 
       rayVec[0] = xratio * maxRay[0];
       rayVec[1] = yratio * maxRay[1];
       // rayVec[2] = -1.0;
       // rayVec[3] = 0.0;
       return;
-    }
-  }
-
-  function initCursor() {
-    // What does an animation need to know about the cursor at each frame?
-    // First, whether the user did any of the following since the last frame:
-    //  - Started new actions
-    var touchStarted = false; // Touched or clicked the element
-    var zoomStarted  = false; // Rotated mousewheel, or started two-finger touch
-    //  - Changed something
-    var moved  = false;       // Moved mouse or touch point
-    var zoomed = false;       // Rotated mousewheel, or adjusted two-finger touch
-    //  - Is potentially in the middle of something
-    var tapping = false;      // No touchEnd, and no cursor motion
-    //  - Ended actions
-    var touchEnded = false;   // mouseup or touchend/cancel/leave
-    var tapped = false;       // Completed a click or tap action
-
-    // We also need to know the current cursor position and zoom scale
-    var cursorX = 0;
-    var cursorY = 0;
-    var zscale = 1.0;
-
-    // For tap/click reporting, we need to remember where the touch started
-    var startX = 0;
-    var startY = 0;
-    // What is a click/tap and what is a drag? If the cursor moved more than
-    // this threshold between touchStart and touchEnd, it is a drag
-    const threshold = 6;
-
-    return {
-      // Methods to report local state. Return a copy to protect local values
-      touchStarted: () => touchStarted,
-      zoomStarted: () => zoomStarted,
-      moved: () => moved,
-      zoomed: () => zoomed,
-      tapped: () => tapped,
-      touchEnded: () => touchEnded,
-      hasChanged: () => (moved || zoomed || tapped),
-      zscale: () => zscale,
-      x: () => cursorX,
-      y: () => cursorY,
-
-      // Methods to update local state
-      startTouch,
-      startZoom,
-      move,
-      zoom,
-      endTouch,
-      reset,
-    };
-
-    function startTouch(evnt) {
-      cursorX = evnt.clientX;
-      cursorY = evnt.clientY;
-      touchStarted = true;
-      startX = cursorX;
-      startY = cursorY;
-      tapping = true;
-    }
-
-    function startZoom(evnt) {
-      // Store the cursor position
-      cursorX = evnt.clientX;
-      cursorY = evnt.clientY;
-      zoomStarted = true;
-      tapping = false;
-    }
-
-    function move(evnt) {
-      cursorX = evnt.clientX;
-      cursorY = evnt.clientY;
-      moved = true;
-      var dist = Math.abs(cursorX - startX) + Math.abs(cursorY - startY);
-      if (dist > threshold) tapping = false;
-    }
-
-    function zoom(scale) {
-      zscale *= scale;
-      zoomed = true;
-      tapping = false;
-    }
-
-    function endTouch() {
-      if (touchStarted) {
-        // Ending a new touch? Just ignore both // TODO: is this a good idea?
-        touchStarted = false;
-        touchEnded = false;
-      } else {
-        touchEnded = true;
-      }
-      tapped = tapping;
-      tapping = false;
-    }
-
-    function reset() {
-      touchStarted = false;
-      zoomStarted  = false;
-      moved  = false;
-      zoomed = false;
-      touchEnded = false;
-      // NOTE: we do NOT reset tapping... this could carry over to next check
-      tapped = false;
-      zscale = 1.0;
-    }
-  }
-
-  // Add event listeners to update the state of a cursor object
-  // Input div is an HTML element on which events will be registered
-  function initTouch(div) {
-    const cursor = initCursor();
-
-    // Remember the distance between two pointers
-    var lastDistance = 1.0;
-
-    // Capture the drag event so we can disable any default actions
-    div.addEventListener("dragstart", function(drag) {
-      drag.preventDefault();
-      return false;
-    }, false);
-
-    // Add mouse events
-    div.addEventListener("mousedown",   cursor.startTouch, false);
-    div.addEventListener("mousemove",   cursor.move,       false);
-    div.addEventListener("mouseup",     cursor.endTouch,   false);
-    div.addEventListener("mouseleave",  cursor.endTouch,   false);
-    div.addEventListener("wheel",       wheelZoom,         false);
-
-    // Add touch events
-    div.addEventListener("touchstart",  initTouch,       false);
-    div.addEventListener("touchmove",   moveTouch,       false);
-    div.addEventListener("touchend",    cursor.endTouch, false);
-    div.addEventListener("touchcancel", cursor.endTouch, false);
-
-    // Return a pointer to the cursor object
-    return cursor;
-
-    function initTouch(evnt) {
-      const { preventDefault, touches } = evnt;
-      preventDefault();
-      switch (touches.length) {
-        case 1:
-          cursor.startTouch(touches[0]);
-          break;
-        case 2:
-          var midpoint = getMidPoint(touches[0], touches[1]);
-          cursor.startTouch(midpoint);
-          cursor.startZoom(midpoint);
-          // Initialize the starting distance between touches
-          lastDistance = midpoint.distance;
-          break;
-        default:
-          cursor.endTouch(evnt);
-      }
-    }
-
-    function moveTouch(evnt) {
-      const { preventDefault, touches } = evnt;
-      preventDefault();
-      // NOTE: MDN says to add the touchmove handler within the touchstart handler
-      // https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events
-      switch (touches.length) {
-        case 1:
-          cursor.move(touches[0]);
-          break;
-        case 2:
-          var midpoint = getMidPoint(touches[0], touches[1]);
-          // Move the cursor to the midpoint
-          cursor.move(midpoint);
-          // Zoom based on the change in distance between the two touches
-          cursor.zoom(lastDistance / midpoint.distance);
-          // Remember the new touch distance
-          lastDistance = midpoint.distance;
-          break;
-        default:
-          return false;
-      }
-    }
-
-    // Convert a two-touch event to a single event at the midpoint
-    function getMidPoint(p0, p1) {
-      var dx = p1.clientX - p0.clientX;
-      var dy = p1.clientY - p0.clientY;
-      return {
-        clientX: p0.clientX + dx / 2,
-        clientY: p0.clientY + dy / 2,
-        distance: Math.sqrt(dx * dx + dy * dy),
-      };
-    }
-
-    function wheelZoom(turn) {
-      turn.preventDefault();
-      cursor.startZoom(turn);
-      // We ignore the dY from the browser, since it may be arbitrarily scaled
-      // based on screen resolution or other factors. We keep only the sign.
-      // See https://github.com/Leaflet/Leaflet/issues/4538
-      var zoomScale = 1.0 + 0.2 * Math.sign(turn.deltaY);
-      cursor.zoom(zoomScale);
     }
   }
 
@@ -9065,37 +8866,6 @@ function sendTile(id, tile) {
     var y = a[1];
     var z = a[2];
     return Math.hypot(x, y, z);
-  }
-  /**
-   * Set the components of a vec3 to the given values
-   *
-   * @param {vec3} out the receiving vector
-   * @param {Number} x X component
-   * @param {Number} y Y component
-   * @param {Number} z Z component
-   * @returns {vec3} out
-   */
-
-  function set(out, x, y, z) {
-    out[0] = x;
-    out[1] = y;
-    out[2] = z;
-    return out;
-  }
-  /**
-   * Adds two vec3's
-   *
-   * @param {vec3} out the receiving vector
-   * @param {ReadonlyVec3} a the first operand
-   * @param {ReadonlyVec3} b the second operand
-   * @returns {vec3} out
-   */
-
-  function add(out, a, b) {
-    out[0] = a[0] + b[0];
-    out[1] = a[1] + b[1];
-    out[2] = a[2] + b[2];
-    return out;
   }
   /**
    * Subtracts vector b from vector a
@@ -9263,59 +9033,108 @@ function sendTile(id, tile) {
     };
   })();
 
+  function initRayGun(M, meanRadius) {
+    // All method arguments are vec3s in ECEF coordinates
+    return { shoot: shootEllipsoid, findHorizon };
+
+    function shootEllipsoid(intersection, camera, rayVec) {
+      // Input rayVec: direction of a ray shot from camera
+      // Outputs position of the intersection of the ray with the ellipsoid
+
+      // Math: solving for values t where || M (camera + t*rayVec) || = 1,
+      const mCam = M(camera);
+      const mRay = M(rayVec);
+
+      // We now have <mRay,mRay>*t^2 + 2*<mRay,mCam>*t + <mCam,mCam> - 1 = 0
+      const a = dot(mRay, mRay);
+      const b = 2.0 * dot(mRay, mCam);
+      const c = dot(mCam, mCam) - 1.0;
+      const discriminant = b ** 2 - 4 * a * c;
+
+      const intersected = (discriminant >= 0);
+
+      // There are generally 2 intersections. We want the closer one, with
+      // smallest positive t. (b < 0, if ray is back from camera to ellipsoid)
+      // If no intersection, find the point on the ray that comes closest to the
+      // unit sphere: minimize a*t^2 + b*t + c (get zero of derivative)
+      // NOTE: NOT the closest point on the ellipsoid! And NOT on the horizon!
+      const t = (intersected)
+        ? (-b - Math.sqrt(discriminant)) / (2.0 * a)
+        : -0.5 * b / a;
+
+      // NOTE: rayVec is actually a vec4
+      scaleAndAdd(intersection, camera, rayVec, t);
+      return intersected; // Indicates whether the ray did in fact hit
+    }
+
+    function findHorizon(horizon, camera, rayVec) {
+      // Find the point on the horizon under rayvec.
+      // We first adjust rayVec to point it toward the horizon, and then
+      // re-shoot the ellipsoid with the corrected ray
+      const dRay = new Float64Array(3);
+
+      // 1. Find the component of rayVec parallel to camera direction
+      normalize(dRay, camera); // Unit vector along camera direction
+      const paraLength = dot(dRay, rayVec);
+      scale(dRay, dRay, paraLength);
+
+      // 2. Find the component perpendicular to camera direction
+      subtract(dRay, rayVec, dRay);
+      const perpLength = length(dRay);
+      if (perpLength == 0) return false; // No solution if ray is vertical
+
+      // 3. Find the error of the length of the perpendicular component
+      const sinAlpha = meanRadius / length(camera); // sin(angle to horizon)
+      const tanAlpha = sinAlpha / Math.sqrt(1.0 - sinAlpha * sinAlpha);
+      const dPerp = -paraLength * tanAlpha - perpLength;
+
+      // 4. Find the corrected rayVec
+      scaleAndAdd(dRay, rayVec, dRay, dPerp / perpLength);
+
+      // 5. Re-shoot the ellipsoid with the corrected rayVec
+      shootEllipsoid(horizon, camera, dRay);
+      return true;
+    }
+  }
+
   function initEcefToLocalGeo() {
-    const { cos, sin, sqrt } = Math;
-    var sinLon, cosLon, sinLat, cosLat;
+    const { cos, sin, hypot } = Math;
     const toENU = new Float64Array(9);
 
-    return ecefToDeltaLonLatAlt;
-
-    function ecefToDeltaLonLatAlt( delta, diff, anchor, viewPos ) {
-      // Inputs are pointers to vec3s. anchor is a position in ECEF coordinates.
-      // diff represents a differential change (e.g. motion?) near anchor.
+    return function ecefToDeltaLonLatAlt(delta, diff, anchor, viewPos) {
+      // Inputs are in ECEF coords. viewPos represents the position of the model
+      //   coordinates relative to the view coordinates.
+      // Input diff represents a differential change (e.g. motion?) near anchor
       // Output delta will be the corresponding differentials in lon/lat/alt
-      // viewPos represents the position of the model coordinates (ECEF) relative
-      // to the view coordinates.    WARNING: diff will be overwritten
+
+      // 0. Compute sines and cosines of longitude and latitude at anchor, which
+      // is a surface normal on an ellipsoid (or an ECEF position on a sphere)
+      const [x, y, z] = anchor;
+      const p = hypot(x, z);
+      const cosLon = (p > 0) ? z / p : 0.0;
+      const sinLon = (p > 0) ? x / p : 0.0;
+      const r = hypot(x, y, z);
+      const cosLat = p / r;
+      const sinLat = y / r;
 
       // 1. Transform to local East-North-Up coordinates at the anchor location
-      setupENU( anchor );
-      transformMat3( diff, diff, toENU );
+      setupENU(cosLon, sinLon, cosLat, sinLat);
+      transformMat3(delta, diff, toENU);
 
       // 2. Convert horizontal component to changes in longitude, latitude
-      const r = length(anchor);
-      delta[0] = diff[0] / r / (cosLat + 0.0001); // +0.0001 avoids /0
-      delta[1] = diff[1] / r;
-      delta[2] = diff[2];
+      delta[0] = delta[0] / r / (cosLat + 0.0001); // +0.0001 avoids /0
+      delta[1] = delta[1] / r;
 
       // 3. Latitudinal change is a rotation about an axis in the x-z plane, with
       // direction vec3.cross(anchor,North), or -East. We only want the component
       // rotating about the x-axis in view coordinates.
       delta[1] *= (cos(viewPos[0]) * cosLon + sin(viewPos[0]) * sinLon);
-      return;
-    }
+    };
 
-    function setupENU( normal ) {
-      // Setup the matrix to rotate from global Earth-Centered-Earth-Fixed
-      // to local East-North-Up coordinates. Assumptions for input ECEF:
-      //    y-axis is the polar axis
-      //   +z-axis points toward latitude = longitude = 0.
-      // Input normal is an ellipsoid surface normal at the desired ENU origin
-
-      // Update sines and cosines of the latitude and longitude of the normal
-      const p2 = normal[0] ** 2 + normal[2] ** 2;
-      const p = sqrt(p2);
-      if (p > 0) {
-        sinLon = normal[0] / p;
-        cosLon = normal[2] / p;
-      } else {
-        sinLon = 0.0;
-        cosLon = 0.0;
-      }
-      const r = sqrt(p2 + normal[1] ** 2);
-      sinLat = normal[1] / r;
-      cosLat = p / r;
-
-      // Build matrix. Follows Widnal & Peraire (MIT) p.7, with the axes renamed:
+    function setupENU(cosLon, sinLon, cosLat, sinLat) {
+      // Build matrix to rotate from global Earth-Centered-Earth-Fixed
+      // to local East-North-Up coordinates.
+      // Follows Widnal & Peraire (MIT) p.7, with axes renamed:
       //   z -> y, y -> x, x -> z
       // Using OpenGL COLUMN-MAJOR format!!
       toENU[0] =  cosLon;
@@ -9333,12 +9152,12 @@ function sendTile(id, tile) {
       // Elements (0, 3, 6) = unit vector in East direction
       // Elements (1, 4, 7) = unit vector in North direction
       // Elements (2, 5, 8) = unit vector in Up direction
-      return;
     }
   }
 
   function initEllipsoid() {
-    const { atan2, sin, cos, sqrt } = Math;
+    const { atan2, sin, cos, sqrt, hypot } = Math;
+
     // Store ellipsoid parameters
     const semiMajor = 6371.0;  // kilometers
     const semiMinor = 6371.0;  // kilometers
@@ -9346,136 +9165,119 @@ function sendTile(id, tile) {
     // https://en.wikipedia.org/wiki/Earth_radius#Mean_radius
     const meanRadius = (2.0 * semiMajor + semiMinor) / 3.0;
 
-    // Working vectors for shootEllipsoid, findHorizon
-    const mCam = new Float64Array(3);
-    const mRay = new Float64Array(3);
-    const dRay = new Float64Array(3);
+    // M: matrix to scale ellipsoid to unit sphere. The ellipsoid is
+    // aligned with the coordinate axes, so we can store only the diagonal
+    const Mdiag = [semiMajor, semiMinor, semiMajor];
+    const M = vec => vec.map((c, i) => c / Mdiag[i]);
+
+    const { shoot, findHorizon } = initRayGun(M, meanRadius);
 
     return {
       meanRadius: () => meanRadius,
       ecef2geocentric,
       ecefToDeltaLonLatAlt: initEcefToLocalGeo(),
       geodetic2ecef,
-      shoot: shootEllipsoid,
+      shoot,
       findHorizon,
     };
 
     function ecef2geocentric(gcPos, ecefPos) {
-      // Output gcPos is a pointer to a 3-element array, containing geocentric
-      //  longitude & latitude (radians) and altitude (meters) coordinates
-      // Input ecefPos is a pointer to a 3-element array, containing earth-
-      //  centered earth-fixed x,y,z coordinates in the WebGL axis definition
+      // Input earth-centered earth-fixed coords are in WebGL axis definition
+      const [x, y, z] = ecefPos;
 
-      // Note: order of calculations is chosen to allow calls with same array
-      // as input & output (gcPos, ecefPos point to same array)
-
-      // Compute squared distance from polar axis
-      const p2 = ecefPos[0] ** 2 + ecefPos[2] ** 2;
-
-      gcPos[0] = atan2(ecefPos[0], ecefPos[2]);     // Longitude
-      gcPos[1] = atan2(ecefPos[1], sqrt(p2));  // Latitude
-
-      // NOTE: this "altitude" is distance from SPHERE, not ellipsoid
-      gcPos[2] = sqrt(p2 + ecefPos[1] ** 2) - meanRadius; // Altitude
-      return;
+      // Output coords are geocentric: valid for a SPHERE, not an ellipsoid
+      gcPos[0] = atan2(x, z); // Longitude (radians)
+      gcPos[1] = atan2(y, hypot(x, z)); // Latitude (radians)
+      gcPos[2] = hypot(x, y, z) - meanRadius; // Altitude (kilometers)
     }
 
     function geodetic2ecef(ecef, geodetic) {
-      // Output ecef is a pointer to a 3-element array containing X,Y,Z values
-      //   of the point in earth-centered earth-fixed (ECEF) coordinates
-      // Input geodetic is a pointer to a 3-element array, containing
-      //   longitude & latitude (in radians) and altitude (in meters)
+      // Input geodetic units: [radians, radians, kilometers]
+      const [lon, lat, alt] = geodetic;
 
       // Start from prime vertical radius of curvature -- see
       // https://en.wikipedia.org/wiki/Geographic_coordinate_conversion
-      const sinLat = sin( geodetic[1] );
-      const primeVertRad = semiMajor / sqrt( 1.0 - e2 * sinLat ** 2 );
+      const sinLat = sin(lat);
+      const primeVertRad = semiMajor / sqrt(1.0 - e2 * sinLat ** 2);
       // Radial distance from y-axis:
-      const p = (primeVertRad + geodetic[2]) * cos(geodetic[1]);
+      const p = (primeVertRad + alt) * cos(lat);
 
-      // Compute ECEF position
-      ecef[0] = p * sin(geodetic[0]);
-      ecef[1] = (primeVertRad + geodetic[2]) * sinLat * (1.0 - e2);
-      ecef[2] = p * cos(geodetic[0]);
-      return;
+      // Compute earth-centered earth-fixed (ECEF) coordinates
+      ecef[0] = p * sin(lon);
+      ecef[1] = (primeVertRad + alt) * sinLat * (1.0 - e2);
+      ecef[2] = p * cos(lon);
+    }
+  }
+
+  function checkCoords(p, n) {
+    const isArray = Array.isArray(p) ||
+      (ArrayBuffer.isView(p) && !(p instanceof DataView));
+    return isArray && p.length >= n &&
+      p.slice(0, n).every(Number.isFinite);
+  }
+
+  function getUnitConversion(units) {
+    // Internally, spinning-ball assumes geodetic coordinates in these units:
+    //   [longitude (radians), latitude (radians), altitude (kilometers)]
+    // Externally, the user may want longitude and latitude in degrees.
+    // Construct the functions that convert user inputs to internal coordinates,
+    // and invert internal coordinates to the user's units
+    const uPerRad = (units === "degrees")
+      ? 180.0 / Math.PI
+      : 1.0;
+
+    return {
+      convert: c => new Float64Array([c[0] / uPerRad, c[1] / uPerRad, c[2]]),
+      invert: c => new Float64Array([c[0] * uPerRad, c[1] * uPerRad, c[2]]),
+    };
+  }
+
+  function setParams$1(params) {
+    const { PI } = Math;
+
+    // TODO: Get user-supplied semiMinor & semiMajor axes?
+    const ellipsoid = initEllipsoid();
+
+    const {
+      display,
+      units: userUnits = "degrees",
+      position = [0.0, 0.0, ellipsoid.meanRadius * 4.0],
+      minHeight = ellipsoid.meanRadius() * 0.00001,
+      maxHeight = ellipsoid.meanRadius() * 8.0,
+    } = params;
+
+    if (!(display instanceof Element)) fail("missing display element");
+
+    if (!["degrees", "radians"].includes(userUnits)) fail("invalid units");
+    const units = getUnitConversion(userUnits);
+
+    // minHeight, maxHeight must be Numbers, positive and not too big
+    const heights = [minHeight, maxHeight];
+    if (!heights.every(h => Number.isFinite(h) && h > 0)) {
+      fail("minHeight, maxHeight must be Numbers > 0");
+    } else if (heights.some(h => h > ellipsoid.meanRadius() * 100000.0)) {
+      fail("minHeight, maxHeight must be somewhere below Jupiter");
     }
 
-    function shootEllipsoid(intersection, camera, rayVec) {
-      // Inputs camera, rayVec are pointers to vec3s indicating the
-      //   position of the camera and the direction of a ray shot from the camera,
-      //   both in earth-centered earth-fixed (ECEF) coordinates
-      // Output intersection is a pointer to a vec3 in ECEF coordinates indicating
-      //   the position of the intersection of the ray with the ellipsoid
-      // Return value indicates whether the ray did in fact intersect the spheroid
+    // initialPosition must be a valid coordinate in the given units
+    if (!checkCoords(position, 3)) fail("invalid center array");
+    const initialPosition = units.convert(position);
+    const [lon, lat, alt] = initialPosition;
+    const outOfRange =
+      lon < -PI || lon > PI ||
+      lat < -PI / 2 || lat > PI / 2 ||
+      alt < minHeight || alt > maxHeight;
+    if (outOfRange) fail ("initial position out of range");
 
-      // Math: solving for values t where || M (camera + t*rayVec) || = 1,
-      //  where M is the matrix that scales the ellipsoid to the unit sphere,
-      //  i.e., for P = (x,y,z), MP = (x/a, y/b, z/c). Since M is diagonal
-      //  (ellipsoid aligned along coordinate axes) we just scale each coordinate.
-      mCam.set([
-        camera[0] / semiMajor,
-        camera[1] / semiMinor,
-        camera[2] / semiMajor
-      ]);
-      mRay.set([
-        rayVec[0] / semiMajor,
-        rayVec[1] / semiMinor,
-        rayVec[2] / semiMajor
-      ]);
+    return {
+      ellipsoid, display, units, initialPosition, minHeight, maxHeight,
+      view: initView(display, 25.0), // Computes ray params at point on display
+    };
+  }
 
-      // We now have <mRay,mRay>*t^2 + 2*<mRay,mCam>*t + <mCam,mCam> - 1 = 0
-      const a = dot(mRay, mRay);
-      const b = 2.0 * dot(mRay, mCam);
-      const c = dot(mCam, mCam) - 1.0;
-      const discriminant = b ** 2 - 4 * a * c;
-
-      const intersected = (discriminant >= 0);
-      var t;
-      if (intersected) {
-        // We want the closest intersection, with smallest positive t
-        // We assume b < 0, if ray is pointing back from camera to ellipsoid
-        t = (-b - sqrt(discriminant)) / (2.0 * a);
-      } else {
-        // Find the point that comes closest to the unit sphere
-        //   NOTE: this is NOT the closest point to the ellipsoid!
-        //   And it is not even the point on the horizon! It is closer...
-        // Minimize a*t^2 + b*t + c, by finding the zero of the derivative
-        t = -0.5 * b / a;
-      }
-
-      // NOTE: rayVec is actually a vec4
-      scaleAndAdd(intersection, camera, rayVec, t);
-      return intersected;
-    }
-
-    function findHorizon(horizon, camera, rayVec) {
-      // Find the point on the horizon under rayvec.
-      // We first adjust rayVec to point it toward the horizon, and then
-      // re-shoot the ellipsoid with the corrected ray
-
-      // 1. Find the component of rayVec parallel to camera direction
-      normalize(dRay, camera); // Unit vector along camera direction
-      const paraLength = dot(dRay, rayVec);
-      scale( dRay, dRay, paraLength );
-
-      // 2. Find the component perpendicular to camera direction
-      subtract( dRay, rayVec, dRay );
-      const perpLength = length(dRay);
-      if (perpLength == 0) return false; // No solution if ray is vertical
-
-      // 3. Find the error of the length of the perpendicular component
-      const sinAlpha = meanRadius / length(camera); // sin(angle to horizon)
-      const tanAlpha = sinAlpha / sqrt(1.0 - sinAlpha * sinAlpha);
-      const dPerp = -paraLength * tanAlpha - perpLength;
-
-      // 4. Find the corrected rayVec
-      scaleAndAdd(dRay, rayVec, dRay, dPerp / perpLength);
-
-      // 5. Re-shoot the ellipsoid with the corrected rayVec
-      shootEllipsoid(horizon, camera, dRay);
-
-      return true;
-    }
+  function fail(message) {
+    // TODO: Should some errors be RangeErrors or TypeErrors instead?
+    throw Error("spinning-ball: " + message);
   }
 
   /**
@@ -9647,14 +9449,12 @@ function sendTile(id, tile) {
     // coordinates and a rotation matrix
     // These are suitable for rendering Relative To Eye (RTE), as described in
     // P Cozzi, 3D Engine Design for Virtual Globes, www.virtualglobebook.com
+    const { min, max, PI } = Math;
     const position = new Float64Array([0.0, 0.0, 0.0, 1.0]);
     const rotation = create$1();  // Note: single precision!! (Float32Array)
     const inverse  = create$1();
 
-    const halfPi = Math.PI / 2.0;
-
-    // Set initial values
-    update(initialPos);
+    update(initialPos); // Set initial values
 
     return {
       position, // WARNING: Exposes local array to changes from outside
@@ -9665,25 +9465,278 @@ function sendTile(id, tile) {
 
     function update(geodetic) {
       // Limit rotation around screen x-axis to keep global North pointing up
-      geodetic[1] = Math.min(Math.max(-halfPi, geodetic[1]), halfPi);
+      geodetic[1] = min(max(-PI / 2.0, geodetic[1]), PI / 2.0);
       // Avoid accumulation of large values in longitude
-      if (geodetic[0] >  Math.PI) geodetic[0] -= 2.0 * Math.PI;
-      if (geodetic[0] < -Math.PI) geodetic[0] += 2.0 * Math.PI;
+      if (geodetic[0] >  PI) geodetic[0] -= 2.0 * PI;
+      if (geodetic[0] < -PI) geodetic[0] += 2.0 * PI;
 
       // Compute ECEF coordinates. NOTE WebGL coordinate convention:
       // +x to right, +y to top of screen, and +z into the screen
-      ellipsoid.geodetic2ecef( position, geodetic );
+      ellipsoid.geodetic2ecef(position, geodetic);
 
       // Rotation: y first, so it will be left of x operator in final matrix
       // (gl-matrix library 'post-multplies' by each new matrix)
       // Positive angles about Y are towards the +X axis, or East longitude.
-      fromYRotation( rotation, geodetic[0] );
+      fromYRotation(rotation, geodetic[0]);
       // Positive angles about X are towards the -Y axis!
       // (from Y to Z, and Z to -Y). But geodetic[1] is a latitude, toward N
-      rotateX( rotation, rotation, -geodetic[1] );
+      rotateX(rotation, rotation, -geodetic[1]);
 
       // The inverse of a rotation matrix is its transpose
-      transpose( inverse, rotation );
+      transpose(inverse, rotation);
+    }
+  }
+
+  function initCamera(params) {
+    const { view, ellipsoid, initialPosition } = params;
+    const rayVec = new Float64Array(3);
+    const ecefTmp = new Float64Array(3);
+
+    // [longitude (radians), latitude (radians), altitude (kilometers)]
+    const position = new Float64Array(initialPosition);
+
+    const ecef = initECEF(ellipsoid, position);
+
+    return {
+      position: () => position.slice(),
+      ecefPos: ecef.position, // WARNING: exposed to changes from outside!
+      rotation: ecef.rotation,
+
+      project,
+      ecefToScreenRay,
+      update,
+    };
+
+    function update(dPos) {
+      if (dPos.every(c => c == 0.0)) return;
+      position.set(position.map((c, i) => c + dPos[i]));
+      ecef.update(position);
+    }
+
+    function project(xy, geodetic) {
+      // Project a geodetic position on the ellipsoid (lon, lat, alt)
+      //  to a position on the display (x, y in pixels)
+      ellipsoid.geodetic2ecef(ecefTmp, geodetic);
+      const visible = ecefToScreenRay(rayVec, ecefTmp);
+
+      xy[0] = view.width() * (1 + rayVec[0] / view.rightEdge()) / 2;
+      xy[1] = view.height() * (1 - rayVec[1] / view.topEdge()) / 2;
+      return visible;
+    }
+
+    function ecefToScreenRay(screenRay, ecefPoint) {
+      // Find the screenRay (from camera position) that intersects ecefPoint
+
+      // Translate to camera position
+      subtract(rayVec, ecefPoint, ecef.position);
+      // rayVec now points from camera to ecef. The sign of the
+      // dot product tells us whether it is beyond the horizon
+      const visible = dot(rayVec, ecefPoint) < 0;
+
+      // Rotate to camera orientation
+      transformMat4$1(screenRay, rayVec, ecef.inverse);
+
+      // Normalize to z = -1
+      screenRay[0] /= -screenRay[2];
+      screenRay[1] /= -screenRay[2];
+      screenRay[2] = -1.0;
+
+      return visible;
+    }
+  }
+
+  function initCursor() {
+    // What does an animation need to know about the cursor at each frame?
+    // First, whether the user did any of the following since the last frame:
+    //  - Started new actions
+    let touchStarted = false; // Touched or clicked the element
+    let zoomStarted  = false; // Rotated mousewheel, or started two-finger touch
+    //  - Changed something
+    let moved  = false;       // Moved mouse or touch point
+    let zoomed = false;       // Rotated mousewheel, or adjusted two-finger touch
+    //  - Is potentially in the middle of something
+    let tapping = false;      // No touchEnd, and no cursor motion
+    //  - Ended actions
+    let touchEnded = false;   // mouseup or touchend/cancel/leave
+    let tapped = false;       // Completed a click or tap action
+
+    // We also need to know the current cursor position and zoom scale
+    let cursorX = 0;
+    let cursorY = 0;
+    let zscale = 1.0;
+
+    // For tap/click reporting, we need to remember where the touch started
+    let startX = 0;
+    let startY = 0;
+    // What is a click/tap and what is a drag? If the cursor moved more than
+    // this threshold between touchStart and touchEnd, it is a drag
+    const threshold = 6;
+
+    return {
+      // Methods to report local state. Return a copy to protect local values
+      touchStarted: () => touchStarted,
+      zoomStarted: () => zoomStarted,
+      moved: () => moved,
+      zoomed: () => zoomed,
+      tapped: () => tapped,
+      touchEnded: () => touchEnded,
+      hasChanged: () => (moved || zoomed || tapped),
+      zscale: () => zscale,
+      x: () => cursorX,
+      y: () => cursorY,
+
+      // Methods to update local state
+      startTouch,
+      startZoom,
+      move,
+      zoom,
+      endTouch,
+      reset,
+    };
+
+    function startTouch(evnt) {
+      cursorX = evnt.clientX;
+      cursorY = evnt.clientY;
+      touchStarted = true;
+      startX = cursorX;
+      startY = cursorY;
+      tapping = true;
+    }
+
+    function startZoom(evnt) {
+      // Store the cursor position
+      cursorX = evnt.clientX;
+      cursorY = evnt.clientY;
+      zoomStarted = true;
+      tapping = false;
+    }
+
+    function move(evnt) {
+      cursorX = evnt.clientX;
+      cursorY = evnt.clientY;
+      moved = true;
+      const dist = Math.abs(cursorX - startX) + Math.abs(cursorY - startY);
+      if (dist > threshold) tapping = false;
+    }
+
+    function zoom(scale) {
+      zscale *= scale;
+      zoomed = true;
+      tapping = false;
+    }
+
+    function endTouch() {
+      if (touchStarted) {
+        // Ending a new touch? Just ignore both // TODO: is this a good idea?
+        touchStarted = false;
+        touchEnded = false;
+      } else {
+        touchEnded = true;
+      }
+      tapped = tapping;
+      tapping = false;
+    }
+
+    function reset() {
+      touchStarted = false;
+      zoomStarted  = false;
+      moved  = false;
+      zoomed = false;
+      touchEnded = false;
+      // NOTE: we do NOT reset tapping... this could carry over to next check
+      tapped = false;
+      zscale = 1.0;
+    }
+  }
+
+  function initTouch(div) {
+    // Add event listeners to update the state of a cursor object
+    // Input div is an HTML element on which events will be registered
+    const cursor = initCursor();
+
+    // Remember the distance between two pointers
+    let lastDistance = 1.0;
+
+    div.addEventListener("dragstart", d => d.preventDefault(), false);
+
+    // Add mouse events
+    div.addEventListener("mousedown",   cursor.startTouch, false);
+    div.addEventListener("mousemove",   cursor.move,       false);
+    div.addEventListener("mouseup",     cursor.endTouch,   false);
+    div.addEventListener("mouseleave",  cursor.endTouch,   false);
+    div.addEventListener("wheel",       wheelZoom,         false);
+
+    // Add touch events
+    div.addEventListener("touchstart",  initTouch,       false);
+    div.addEventListener("touchmove",   moveTouch,       false);
+    div.addEventListener("touchend",    cursor.endTouch, false);
+    div.addEventListener("touchcancel", cursor.endTouch, false);
+
+    return cursor;
+
+    function initTouch(evnt) {
+      const { touches } = evnt;
+      evnt.preventDefault();
+      switch (touches.length) {
+        case 1:
+          cursor.startTouch(touches[0]);
+          break;
+        case 2: {
+          const midpoint = getMidPoint(touches[0], touches[1]);
+          cursor.startTouch(midpoint);
+          cursor.startZoom(midpoint);
+          // Initialize the starting distance between touches
+          lastDistance = midpoint.distance;
+          break;
+        }
+        default:
+          cursor.endTouch(evnt);
+      }
+    }
+
+    function moveTouch(evnt) {
+      const { touches } = evnt;
+      evnt.preventDefault();
+      // NOTE: MDN says to add the touchmove handler within the touchstart handler
+      // https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events
+      switch (touches.length) {
+        case 1:
+          cursor.move(touches[0]);
+          break;
+        case 2: {
+          const midpoint = getMidPoint(touches[0], touches[1]);
+          // Move the cursor to the midpoint
+          cursor.move(midpoint);
+          // Zoom based on the change in distance between the two touches
+          cursor.zoom(lastDistance / midpoint.distance);
+          // Remember the new touch distance
+          lastDistance = midpoint.distance;
+          break;
+        }
+        default:
+          return false;
+      }
+    }
+
+    // Convert a two-touch event to a single event at the midpoint
+    function getMidPoint(p0, p1) {
+      const dx = p1.clientX - p0.clientX;
+      const dy = p1.clientY - p0.clientY;
+      return {
+        clientX: p0.clientX + dx / 2,
+        clientY: p0.clientY + dy / 2,
+        distance: Math.hypot(dx, dy),
+      };
+    }
+
+    function wheelZoom(turn) {
+      turn.preventDefault();
+      cursor.startZoom(turn);
+      // We ignore the dY from the browser, since it may be arbitrarily scaled
+      // based on screen resolution or other factors. We keep only the sign.
+      // See https://github.com/Leaflet/Leaflet/issues/4538
+      const zoomScale = 1.0 + 0.2 * Math.sign(turn.deltaY);
+      cursor.zoom(zoomScale);
     }
   }
 
@@ -9778,434 +9831,63 @@ function sendTile(id, tile) {
     };
   })();
 
-  function initEdgePoints(ellipsoid, camPos, camRot, screen) {
-    // Allocate working arrays and variables
-    const rayVec = new Float64Array([0.0, 0.0, -1.0, 0.0]);
-    const camRay = new Float64Array(4);
-    const rayHit = new Float64Array(3);
-    var tanX, tanY;
+  function initCursor2d(params, camera) {
+    const { display, view, ellipsoid } = params;
 
-    // Construct a list of points around the screen edges
-    const screenPoints = [
-      [-1.0, -1.0], // Bottom left
-      [-0.5, -1.0],
-      [0.0, -1.0], // Bottom center
-      [0.5, -1.0],
-      [1.0, -1.0], // Bottom right
-      [1.0, -0.5],
-      [1.0,  0.0], // Right center
-      [1.0,  0.5],
-      [1.0,  1.0], // Top right
-      [0.5,  1.0],
-      [0.0,  1.0], // Top center
-      [-0.5,  1.0],
-      [-1.0,  1.0], // Top left
-      [-1.0,  0.5],
-      [-1.0,  0.0], // Left center
-      [-1.0, -0.5],
-      [-1.0, -1.0], // Loop back to bottom left
-    ];
+    const cursor2d = initTouch(display);
 
-    // An edgePoint is the point on the ellipsoid visible from screenPoint
-    const edgePoints = screenPoints.map(() => []);
-    update();
+    const screenRay = new Float64Array([0.0, 0.0, -1.0, 0.0]);
+    const ecefRay = new Float64Array(4);
+    const cursorLonLat = new Float64Array(3);
 
-    return {
-      lonLats: edgePoints,  // WARNING: exposed to updates from outside!
-      update,
-    };
+    function project(cursorPosition) {
+      // Project a cursor position on the display (x, y in pixels)
+      //  to an ECEF coordinate on the ellipsoid
 
-    function update() {
-      // Update the view angles at the screen edges
-      tanX = screen.rightEdge();
-      tanY = screen.topEdge();
+      view.getRayParams(screenRay, cursor2d.x(), cursor2d.y());
+      transformMat4(ecefRay, screenRay, camera.rotation);
+      // NOTE: cursorPosition will be overwritten!
+      const onScene = ellipsoid.shoot(cursorPosition, camera.ecefPos, ecefRay);
 
-      // Find the ellipsoid intersection at each screen point
-      screenPoints.forEach(shoot);
+      // Convert to longitude/latitude/altitude
+      if (onScene) ellipsoid.ecef2geocentric(cursorLonLat, cursorPosition);
+
+      return onScene;
     }
 
-    function shoot(screenPos, index) {
-      // Construct the ray vector
-      rayVec[0] = screenPos[0] * tanX;
-      rayVec[1] = screenPos[1] * tanY;
-      // Rotate to model coordinates (Earth-Centered Earth-Fixed)
-      transformMat4(camRay, rayVec, camRot);
-
-      // Find intersection of ray with ellipsoid
-      var hit = ellipsoid.shoot(rayHit, camPos, camRay);
-      // If it didn't intersect, find the nearest point on the horizon
-      if (!hit) ellipsoid.findHorizon(rayHit, camPos, camRay);
-
-      // Convert to longitude/latitude. NOTE: geocentric!!
-      ellipsoid.ecef2geocentric(edgePoints[index], rayHit);
-    }
+    return Object.assign(cursor2d, { project, screenRay, cursorLonLat });
   }
 
-  function updateOscillator(pos, vel, ext, w0, dt, i1, i2) {
-    // Update position and velocity for a critically damped oscillator, following
-    // http://mathworld.wolfram.com/CriticallyDampedSimpleHarmonicMotion.html
+  function initCursor3d(params, camera) {
+    const { initialPosition, minHeight, maxHeight } = params;
 
-    // Inputs/outputs pos, vel are pointers to arrays
-    // Inputs w0, t are primitive floating point values, indicating the
-    //   natural frequency of the oscillator and the time step
-    // Inputs i1, i2 are primitive integer values, indicating components to update
-
-    var expTerm = Math.exp( -w0 * dt );
-
-    for (let i = i1; i <= i2; i++) {
-      var tmp = (vel[i] + w0 * ext[i]) * dt * expTerm;
-      vel[i] += (expTerm - 1) * vel[i] - w0 * tmp;
-      pos[i] += (expTerm - 1) * ext[i] + tmp;
-    }
-    return;
-  }
-
-  // initZoom: Update camera altitude based on target set by mouse wheel events
-  //  or two-finger pinch movements
-  function initZoom( ellipsoid ) {
-    const w0 = 14.14; // Natural frequency of oscillator
-    const minVelocity = 0.001;
-    const maxRotation = 0.15;
-
-    // NOTE: everything below ASSUMES mass = 1
-    var minEnergy = 0.5 * minVelocity * minVelocity;
-    var extension, kineticE, potentialE;
-    const dPos = new Float64Array(3);
-
-    return function( position, velocity, cursor3d, deltaTime, track ) {
-      // Input cursor3d is a pointer to an object
-      // Inputs position, velocity are pointers to 3-element arrays
-      // Input deltaTime is a primitive floating point value
-
-      var targetHeight = cursor3d.zoomTarget();
-
-      // Save old altitude
-      var oldAltitude = position[2];
-
-      dPos[2] = position[2] - targetHeight;
-      updateOscillator(position, velocity, dPos, w0, deltaTime, 2, 2);
-
-      if (track) {
-        // Adjust rotation to keep zoom location fixed on screen
-        dPos.set(position);
-        dragonflyStalk(dPos, cursor3d.zoomRay, cursor3d.zoomPosition, ellipsoid);
-        // Restrict size of rotation in one time step
-        subtract(dPos, dPos, position);
-        var limited = limitRotation(dPos, maxRotation);
-        add(position, position, dPos);
-      }
-
-      // Scale rotational velocity by the ratio of the height change
-      var heightScale = position[2] / oldAltitude;
-      velocity[0] *= heightScale;
-      velocity[1] *= heightScale;
-
-      if (cursor3d.isClicked() || limited) return;
-
-      // Stop if we are already near steady state
-      kineticE = 0.5 * velocity[2] ** 2;
-      extension = position[2] - targetHeight;
-      potentialE = 0.5 * (w0 * extension) ** 2;
-      if (kineticE + potentialE < minEnergy * targetHeight) {
-        targetHeight = position[2];
-        velocity[2] = 0.0;
-        cursor3d.stopZoom();
-      }
-      return;
-    };
-  }
-
-  function limitRotation(dPos, maxRotation) {
-    // Input dPos is a pointer to a 2-element array containing lon, lat changes
-    // maxRotation is a primitive floating point value
-
-    // Check for longitude value crossing antimeridian
-    if (dPos[0] >  Math.PI) dPos[0] -= 2.0 * Math.PI;
-    if (dPos[0] < -Math.PI) dPos[0] += 2.0 * Math.PI;
-
-    if (Math.abs(dPos[0]) > maxRotation) {
-      var tmp = Math.min(Math.max(-maxRotation, dPos[0]), maxRotation) / dPos[0];
-      dPos[0] *= tmp;
-      dPos[1] *= tmp;
-      return true;
-    }
-    return false;
-  }
-
-  // Given a 3D scene coordinate over which a zoom action was initiated,
-  // and a distance between the screen and the center of the 3D scene,
-  // compute the rotations required to align the 3D coordinate along
-  // the original screen ray.  See
-  // https://en.wikipedia.org/wiki/Dragonfly#Motion_camouflage
-  // TODO: Clean this up. Just use difference of lat/lon under ray?
-  function dragonflyStalk(outRotation, ray, scenePos, ellipsoid) {
-    // Output outRotation is a pointer to a vec3
-    // Input ray is a pointer to a vec3
-    // Input scenePos is a pointer to a 3D cursor object
-
-    // Find the ray-sphere intersection in unrotated model space coordinates
-    var target = new Float64Array(3);
-    var unrotatedCamPos = [0.0, 0.0, outRotation[2] + length(scenePos)];
-    var onEllipse = ellipsoid.shoot(target, unrotatedCamPos, ray);
-    if (!onEllipse) return; // No intersection!
-
-    // Find the rotation about the y-axis required to bring scene point into
-    // the  x = target[0]  plane
-    // First find distance of scene point from scene y-axis
-    var sceneR = Math.sqrt( scenePos[0] ** 2 + scenePos[2] ** 2 );
-    // If too short, exit rather than tipping poles out of y-z plane
-    if ( sceneR < Math.abs(target[0]) ) return;
-    var targetRotY = Math.asin( target[0] / sceneR );
-    outRotation[0] =
-      Math.atan2( scenePos[0], scenePos[2] ) - // Y-angle of scene vector
-      // Math.asin( target[0] / sceneR );       // Y-angle of target point
-      targetRotY;
-
-    // We now know the x and y coordinates of the scene vector after rotation
-    // around the y-axis: (x = target[0], y = scenePos[1])
-    // Find the z-coordinate so we can compute the remaining required rotation
-    var zRotated = sceneR * Math.cos(targetRotY);
-
-    // Find the rotation about the screen x-axis required to bring the scene
-    // point into the target y = target[1] plane
-    // Assumes 0 angle is aligned along Z, and angle > 0 is rotation toward -y !
-    outRotation[1] =
-      Math.atan2( -1 * target[1], target[2] ) -  // X-angle of target point
-      Math.atan2( -1 * scenePos[1], zRotated );  // X-angle of scene vector
-
-    return;
-  }
-
-  // initRotation: Updates rotations and rotation velocities based on forces
-  // applied via a mouse click & drag event.
-  function initRotation( ellipsoid ) {
-    const w0 = 40.0;
-    const extension = new Float64Array(3);
-
-    return function(position, velocity, mouse3d, deltaTime) {
-      // Input mouse3d is a pointer to a mouse object
-      // Inputs position, velocity are pointers to vec3s
-      // Input deltaTime is a primitive floating point value
-
-      // Find the displacement of the clicked position on the globe
-      // from the current mouse position
-      subtract(extension, mouse3d.position, mouse3d.clickPosition);
-
-      // Convert to changes in longitude, latitude, and altitude
-      ellipsoid.ecefToDeltaLonLatAlt(extension, extension,
-        mouse3d.clickPosition, position);
-      // Ignore altitude change for now
-      extension[2] = 0.0;
-
-      updateOscillator(position, velocity, extension, w0, deltaTime, 0, 1);
-      return;
-    };
-  }
-
-  // initCoast: Update rotations based on a freely spinning globe (no forces)
-  function initCoast( ellipsoid ) {
-    const damping = 3.0;
-    const radius = ellipsoid.meanRadius();
-    const minSpeed = 0.03;
-
-    var dvDamp = 0.0;
-
-    return function( position, velocity, deltaTime ) {
-      // Inputs rotation, rotationVel are pointers to 3-element arrays
-      // Input deltaTime is a primitive value (floating point)
-      // TODO: switch to exact formula? (not finite difference)
-
-      if ( length(velocity) < minSpeed * position[2] / radius ) {
-        // Rotation has almost stopped. Go ahead and stop all the way.
-        set(velocity, 0.0, 0.0, 0.0);
-        return false; // No change to position, no need to re-render
-      }
-
-      // Adjust previous velocities for damping over the past time interval
-      dvDamp = -1.0 * damping * deltaTime;
-      // vec3.scaleAndAdd(velocity, velocity, velocity, dvDamp);
-      velocity[0] += velocity[0] * dvDamp;
-      velocity[1] += velocity[1] * dvDamp;
-
-      // Update rotations
-      // vec3.scaleAndAdd(position, position, velocity, deltaTime);
-      position[0] += velocity[0] * deltaTime;
-      position[1] += velocity[1] * deltaTime;
-      return true;    // Position changed, need to re-render
-    };
-  }
-
-  function initProjector(ellipsoid, camPosition, camInverse, screen) {
-    const rayVec = new Float64Array(3);
-    const ecefTmp = new Float64Array(3);
-
-    return {
-      ecefToScreenRay,
-      lonLatToScreenXY,
-    };
-
-    function lonLatToScreenXY(xy, lonLat) {
-      ellipsoid.geodetic2ecef(ecefTmp, lonLat);
-      const visible = ecefToScreenRay(rayVec, ecefTmp); // Overwrites rayVec!
-
-      xy[0] = screen.width() * ( 1 + rayVec[0] / screen.rightEdge() ) / 2;
-      xy[1] = screen.height() * ( 1 - rayVec[1] / screen.topEdge() ) / 2;
-      return visible;
-    }
-
-    function ecefToScreenRay(screenRay, ecefPosition) {
-      // For a given point on the ellipsoid (in ECEF coordinates) find the
-      // rayVec from a given camera position that will intersect it
-
-      // Translate to camera position
-      subtract(rayVec, ecefPosition, camPosition);
-      // rayVec now points from camera to ecef. The sign of the
-      // dot product tells us whether it is beyond the horizon
-      const visible = ( dot(rayVec, ecefPosition) < 0 );
-
-      // Rotate to camera orientation
-      transformMat4$1(screenRay, rayVec, camInverse);
-
-      // Normalize to z = -1
-      screenRay[0] /= -screenRay[2];
-      screenRay[1] /= -screenRay[2];
-      screenRay[2] = -1.0;
-
-      return visible;
-    }
-  }
-
-  function initCameraDynamics(screen, ellipsoid, initialPosition) {
-    // Position & velocity are computed in latitude & longitude in radians, and
-    //   altitude defined by distance along surface normal, in the same length
-    //   units as semiMajor and semiMinor in ellipsoid.js
-    const position = new Float64Array(initialPosition);
-    const velocity = new Float64Array(3); // Initializes to [0,0,0]
-
-    // Initialize ECEF position, rotation matrix, inverse, and update method
-    const ecef = initECEF(ellipsoid, position);
-
-    // Keep track of the longitude/latitude of the edges of the screen
-    const edges = initEdgePoints(ellipsoid, ecef.position, ecef.rotation, screen);
-    // Initialize transforms from ellipsoid to screen positions
-    const projector = initProjector(ellipsoid,
-      ecef.position, ecef.inverse, screen);
-
-    // Initialize some values and working arrays
-    var time = 0.0;
-    const rayVec = new Float64Array(4);
-
-    // Initialize values & update functions for translations & rotations
-    const zoom   = initZoom(ellipsoid);
-    const rotate = initRotation(ellipsoid);
-    const coast  = initCoast(ellipsoid);
-
-    // Return methods to read/update state
-    return {
-      position, // WARNING: Exposes local array to changes from outside
-      edgesPos: edges.lonLats,
-
-      ecefPos: ecef.position,
-      rotation: ecef.rotation,
-      inverse: ecef.inverse,
-
-      lonLatToScreenXY: projector.lonLatToScreenXY,
-
-      update,
-      stopCoast,
-      stopZoom,
-    };
-
-    function stopCoast() {
-      velocity[0] = 0.0;
-      velocity[1] = 0.0;
-    }
-    function stopZoom() {
-      velocity[2] = 0.0;
-    }
-
-    function update(newTime, resized, cursor3d) {
-      // Input time is a primitive floating point value
-      // Input cursor3d is a pointer to an object
-      const deltaTime = newTime - time;
-      time = newTime;
-      // If timestep too big, wait till next frame to update physics
-      if (deltaTime > 0.25) return resized;
-
-      var needToRender;
-      if ( cursor3d.isClicked() ) {       // Rotate globe based on cursor drag
-        rotate( position, velocity, cursor3d, deltaTime );
-        needToRender = true;
-      } else {                           // Let globe spin freely
-        needToRender = coast( position, velocity, deltaTime );
-      }
-      if ( cursor3d.isZooming() ) {       // Update zoom
-        // Update ECEF position and rotation/inverse matrices
-        ecef.update(position);
-        // Update 2D screen position of 3D zoom position
-        var visible = projector.ecefToScreenRay( rayVec, cursor3d.zoomPosition );
-        if (visible) {
-          if ( cursor3d.isClicked() ) cursor3d.zoomRay.set(rayVec);
-          zoom( position, velocity, cursor3d, deltaTime, cursor3d.zoomFixed() );
-        } else {
-          stopZoom(); // TODO: is this needed? Might want to keep coasting
-          cursor3d.stopZoom();
-        }
-        needToRender = true;
-      }
-
-      needToRender = needToRender || resized;
-      if (needToRender) {
-        ecef.update(position);
-        edges.update();
-      }
-      return needToRender;
-    }
-  }
-
-  function initCursor3d(getRayParams, ellipsoid, initialPosition) {
-    // Input getRayParams is a method from yawgl.initView, converting screen X/Y
-    //  to a ray shooting into 3D space
-    // Input initialPosition is a geodetic lon/lat/alt vector
+    const cursor2d = initCursor2d(params, camera);
 
     // Cursor positions are computed & stored in ECEF coordinates (x,y,z)
     const cursorPosition = new Float64Array(3);
     const clickPosition = new Float64Array(3);
     const zoomPosition = new Float64Array(3);
-    // Derived geocentric longitude, latitude, altitude
-    const cursorLonLat = new Float64Array(3);
-    // Screen ray for the 2D cursor position
-    const cursorRay = new Float64Array([0.0, 0.0, -1.0, 0.0]);
+    // Track target screen ray and altitude for zooming
+    const zoomRay = new Float64Array([0.0, 0.0, -1.0, 0.0]);
+    let targetHeight = initialPosition[2];
 
     // Flags about the cursor state
-    var onScene = false;
-    var clicked = false;
-    var zooming = false;
-    var wasTapped = false;
-    // Whether to fix the screen position of the zoom
-    var zoomFix = false;
+    let onScene = false;
+    let clicked = false;
+    let zooming = false;
+    let wasTapped = false;
+    let zoomFix = false; // Whether to fix the screen position of the zoom
 
-    // Track target altitude for zooming
-    var targetHeight = initialPosition[2];
-    const minHeight = ellipsoid.meanRadius() * 0.00001;
-    const maxHeight = ellipsoid.meanRadius() * 8.0;
-    // Target screen ray for zooming
-    const zoomRay = new Float64Array([0.0, 0.0, -1.0, 0.0]);
-
-    // Local working vector
-    const ecefRay = new Float64Array(4);
-
-    // Return methods to read/update cursorPosition
     return {
       // POINTERs to local arrays. WARNING: local vals can be changed outside!
-      position: cursorPosition, // TODO: why make the name more ambiguous?
-      cursorLonLat,
+      cursorLonLat: cursor2d.cursorLonLat,
+      cursorPosition,
       clickPosition,
       zoomPosition,
       zoomRay,
 
-      // Methods to report local state.
-      // These protect the local value, since primitives are passed by value
+      // Methods to report local state
+      hasChanged: () => cursor2d.hasChanged() || wasTapped,
       isOnScene: () => onScene,
       isClicked: () => clicked,
       wasTapped: () => wasTapped,
@@ -10218,128 +9900,283 @@ function sendTile(id, tile) {
       stopZoom,
     };
 
-    function update(cursor2d, camera) {
-      // Get screen ray in model coordinates (ECEF)
-      getRayParams(cursorRay, cursor2d.x(), cursor2d.y());
-      transformMat4(ecefRay, cursorRay, camera.rotation);
-
-      // Find intersection of ray with ellipsoid
-      onScene = ellipsoid.shoot(cursorPosition, camera.ecefPos, ecefRay);
+    function update(position, dynamics) {
+      onScene = cursor2d.project(cursorPosition);
       if (!onScene) {
-        clicked = false;
-        stopZoom(camera.position[2]);
-        cursor2d.reset();
-        return;
+        clicked = zoomFix = false;
+        return cursor2d.reset();
       }
 
-      // Update cursor longitude/latitude
-      ellipsoid.ecef2geocentric(cursorLonLat, cursorPosition);
-
-      if ( cursor2d.touchEnded() ) {
-        clicked = false;
-        zoomFix = false;
-      }
+      if (cursor2d.touchEnded()) clicked = zoomFix = false;
       wasTapped = cursor2d.tapped();
 
-      if ( cursor2d.touchStarted() ) {
-        // Set click position
+      if (cursor2d.touchStarted()) {
         clicked = true;
         clickPosition.set(cursorPosition);
         // Assuming this is a click or single touch, stop zooming
-        stopZoom(camera.position[2]);
-        // Also stop any coasting in the altitude direction
-        camera.stopZoom();
+        stopZoom(position[2]);
+        dynamics.stopZoom(); // Stops coasting in altitude direction
         // If this was actually a two-touch zoom, then cursor2d.zoomStarted()...
       }
 
-      if ( cursor2d.zoomStarted() ) {
-        zooming = true;
-        zoomFix = true;
+      if (cursor2d.zoomStarted()) {
+        zooming = zoomFix = true;
         zoomPosition.set(cursorPosition);
-        zoomRay.set(cursorRay);
-        if (!clicked) camera.stopCoast();
+        zoomRay.set(cursor2d.screenRay);
+        if (!clicked) dynamics.stopCoast();
       }
 
-      if ( cursor2d.zoomed() ) {
+      if (cursor2d.zoomed()) {
         zooming = true;
         targetHeight *= cursor2d.zscale();
         targetHeight = Math.min(Math.max(minHeight, targetHeight), maxHeight);
       }
 
       cursor2d.reset();
-      return;
     }
 
     function stopZoom(height) {
-      zooming = false;
-      zoomFix = false;
+      zooming = zoomFix = false;
       if (height !== undefined) targetHeight = height;
     }
   }
 
-  const degrees = 180.0 / Math.PI;
+  function oscillatorChange(x, v, t, w0) {
+    // For a critically damped oscillator with natural frequency w0, find
+    // the change in position x and velocity v over timestep t.  See
+    // https://mathworld.wolfram.com/CriticallyDampedSimpleHarmonicMotion.html
+    const expTerm = Math.exp(-w0 * t);
+    const Bt = (v + w0 * x) * t;
+    const dx = (x + Bt) * expTerm - x;
+    const dv = (v - w0 * Bt) * expTerm - v;
+    return [dx, dv];
+  }
 
-  function init$1(display, center, altitude) {
-    // Input display is an HTML element where the ball will be represented
-    // Input center is a pointer to a 2-element array containing initial
-    // longitude and latitude for the camera
-    // Input altitude is a floating point value indicating initial altitude
+  function getCamPos(centerDist, zoomPos, zoomRay, ellipsoid) {
+    // See https://en.wikipedia.org/wiki/Dragonfly#Motion_camouflage
+    // Returns the [lon, lat] where a camera at centerDist km from the
+    // ellipsoid center will have zoomPos aligned along zoomRay
+    const { abs, hypot, asin, cos, atan2 } = Math;
 
-    // Add event handlers and position tracking to display element
-    const cursor2d = initTouch(display);
-    // Add a view object to compute ray parameters at points on the display
-    const view = initView(display, 25.0);
+    // Find the ray-sphere intersection in unrotated model space coordinates
+    const unrotatedCamPos = [0.0, 0.0, centerDist];
+    const target = new Float64Array(3);
+    const intersected = ellipsoid.shoot(target, unrotatedCamPos, zoomRay);
+    if (!intersected) return;
 
-    // Initialize ellipsoid, and methods for computing positions relative to it
-    const ellipsoid = initEllipsoid();
+    // Find the rotation about the y-axis required to bring zoomPos into the
+    // x = target[0] plane
+    const [zoomX, zoomY, zoomZ] = zoomPos;
+    const zoomR = hypot(zoomX, zoomZ);
+    if (zoomR < abs(target[0])) return;
+    const targetRotY = asin(target[0] / zoomR); // ?= atan2(target[0], target[2])
+    const rotY = atan2(zoomX, zoomZ) - targetRotY;
 
-    // Initialize camera dynamics: time, position, velocity, etc.
-    // First check and convert user parameters for initial position
-    var initialPos = (center && Array.isArray(center) && center.length === 2)
-      ? [center[0] / degrees, center[1] / degrees]
-      : [0.0, 0.0];
-    initialPos[2] = (altitude)
-      ? altitude
-      : 4.0 * ellipsoid.meanRadius();
-    const camera = initCameraDynamics(view, ellipsoid, initialPos);
+    // After rotation around Y, zoomPos will be aligned with x = target[0].
+    // Now find the rotation around X to align with y = target[1]
+    const targetRotX = atan2(target[2], target[1]);
+    const zRotated = zoomR * cos(targetRotY);
+    const rotX = atan2(zRotated, zoomY) - targetRotX;
 
-    // Initialize interaction with the ellipsoid via the mouse and screen
-    const cursor3d = initCursor3d(view.getRayParams, ellipsoid, camera.position);
+    // Note signs: rotX ~ -latitude
+    return [rotY, -rotX];
+  }
 
-    var camMoving, cursorChanged;
+  function limitRotation(dPos) {
+    const { abs, min, max, PI } = Math;
+    const maxRotation = 0.15;
+
+    // Check for longitude value crossing antimeridian
+    if (dPos[0] >  PI) dPos[0] -= 2.0 * PI;
+    if (dPos[0] < -PI) dPos[0] += 2.0 * PI;
+
+    if (abs(dPos[0]) < maxRotation) return false;
+
+    const tmp = min(max(-maxRotation, dPos[0]), maxRotation) / dPos[0];
+    dPos[0] *= tmp;
+    dPos[1] *= tmp;
+    return true;
+  }
+
+  function initZoom(ellipsoid, cursor3d) {
+    // Update camera altitude based on target set by mouse wheel events
+    //  or two-finger pinch movements
+    const { zoomTarget, zoomPosition, zoomRay, stopZoom } = cursor3d;
+
+    const w0 = 14.14; // Natural frequency of oscillator
+    const minVelocity = 0.001;
+    const minEnergy = 0.5 * minVelocity ** 2; // ASSUME mass == 1
+
+    return function(position, velocity, dt) {
+      const stretch = position[2] - zoomTarget();
+      const [dz, dVz] = oscillatorChange(stretch, velocity[2], dt, w0);
+      velocity[2] += dVz;
+
+      // Scale rotational velocity by the ratio of the height change
+      const heightScale = 1.0 + dz / position[2];
+      velocity[0] *= heightScale;
+      velocity[1] *= heightScale;
+
+      const dPos = new Float64Array([0.0, 0.0, dz]);
+      const centerDist = position[2] + dz + ellipsoid.meanRadius();
+      const newRotation = (cursor3d.zoomFixed())
+        ? getCamPos(centerDist, zoomPosition, zoomRay, ellipsoid)
+        : null;
+      if (newRotation) {
+        dPos[0] = newRotation[0] - position[0];
+        dPos[1] = newRotation[1] - position[1];
+      }
+      const limited = limitRotation(dPos);
+
+      const rotating = cursor3d.isClicked() || limited;
+      const energy = 0.5 * velocity[2] ** 2 + // Kinetic
+        0.5 * (w0 * (stretch + dz)) ** 2;     // Potential
+      // Stop if we are already near steady state
+      if (!rotating && energy < minEnergy * zoomTarget()) {
+        velocity[2] = 0.0;
+        stopZoom();
+      }
+
+      return dPos;
+    };
+  }
+
+  function initRotation(ellipsoid, cursor3d) {
+    // Update rotations and rotation velocities based on forces applied
+    // via a mouse click & drag event
+    const w0 = 40.0;
+    const extension = new Float64Array(3);
+    const { cursorPosition, clickPosition } = cursor3d;
+
+    return function(position, velocity, dt) {
+      // Find the displacement of the clicked position on the globe
+      // from the current mouse position
+      subtract(extension, cursorPosition, clickPosition);
+
+      // Convert to changes in longitude, latitude, and altitude
+      ellipsoid.ecefToDeltaLonLatAlt(extension, extension,
+        clickPosition, position);
+
+      const [x, y] = extension;
+      const [dLon, dVx] = oscillatorChange(x, velocity[0], dt, w0);
+      const [dLat, dVy] = oscillatorChange(y, velocity[1], dt, w0);
+
+      velocity[0] += dVx;
+      velocity[1] += dVy;
+
+      return new Float64Array([dLon, dLat, 0.0]);
+    };
+  }
+
+  function initCoast(ellipsoid) {
+    // Update rotations based on a freely spinning globe (no forces)
+    const damping = 3.0; // Viscous damping
+    const radius = ellipsoid.meanRadius();
+    const minSpeed = 0.03;
+
+    return function(position, velocity, dt) {
+      // TODO: switch to exact formula? (not finite difference)
+
+      const speed = Math.hypot(velocity[0], velocity[1]);
+      if (speed < minSpeed * position[2] / radius) {
+        velocity.fill(0.0, 0, 2);
+        return new Float64Array(3); // No change in position
+      }
+
+      // Adjust previous velocities for damping over the past time interval
+      const dvDamp = -1.0 * damping * dt;
+      velocity[0] += velocity[0] * dvDamp;
+      velocity[1] += velocity[1] * dvDamp;
+
+      // Return change in position
+      const dLon = velocity[0] * dt;
+      const dLat = velocity[1] * dt;
+      return new Float64Array([dLon, dLat, 0.0]);
+    };
+  }
+
+  function initCameraDynamics(ellipsoid, camera, cursor3d) {
+    // Velocity is the time differential of camera.position
+    const velocity = new Float64Array(3);
+
+    // Initialize some values and working arrays
+    let time = 0.0;
+    const rayVec = new Float64Array(4);
+
+    // Initialize values & update functions for translations & rotations
+    const zoom   = initZoom(ellipsoid, cursor3d);
+    const rotate = initRotation(ellipsoid, cursor3d);
+    const coast  = initCoast(ellipsoid);
+
+    // Return methods to read/update state
+    return {
+      update,
+      stopZoom: () => velocity.fill(0.0, 2),
+      stopCoast: () => velocity.fill(0.0, 0, 2),
+    };
+
+    function update(newTime) {
+      const deltaTime = newTime - time;
+      time = newTime;
+      // If timestep too big, wait till next frame to update physics
+      if (deltaTime > 0.25) return false;
+
+      const rotation = (cursor3d.isClicked())
+        ? rotate(camera.position(), velocity, deltaTime)
+        : coast(camera.position(), velocity, deltaTime);
+      camera.update(rotation);
+
+      const rotated = rotation.some(c => c != 0.0);
+      if (!cursor3d.isZooming()) return rotated;
+
+      // Update 2D screen position of 3D zoom position
+      const visible = camera.ecefToScreenRay(rayVec, cursor3d.zoomPosition);
+      if (!visible) {
+        velocity.fill(0.0, 2); // TODO: is this needed? Or keep coasting?
+        cursor3d.stopZoom();
+        return rotated;
+      }
+
+      if (cursor3d.isClicked()) cursor3d.zoomRay.set(rayVec);
+      const zoomChange = zoom(camera.position(), velocity, deltaTime);
+      camera.update(zoomChange);
+      return true;
+    }
+  }
+
+  function init$1(userParams) {
+    const params = setParams$1(userParams);
+    const { ellipsoid, view, units } = params;
+
+    const camera = initCamera(params);
+    const cursor = initCursor3d(params, camera);
+    const dynamics = initCameraDynamics(ellipsoid, camera, cursor);
+
+    let camMoving, cursorChanged;
 
     return {
       view,
-
       radius: ellipsoid.meanRadius,
 
+      project: (xy, geodetic) => camera.project(xy, units.convert(geodetic)),
+      cameraPos: () => units.invert(camera.position()),
+      cursorPos: () => units.invert(cursor.cursorLonLat),
+
       camMoving: () => camMoving,
-      cameraPos: camera.position,
-      edgesPos: camera.edgesPos,
-
-      lonLatToScreenXY: camera.lonLatToScreenXY,
-
-      cursorPos: cursor3d.cursorLonLat,
-      isOnScene: cursor3d.isOnScene,
+      isOnScene: cursor.isOnScene,
+      wasTapped: cursor.wasTapped,
       cursorChanged: () => cursorChanged,
-      wasTapped: cursor3d.wasTapped,
 
       update,
     };
 
     function update(time) {
-      // Input time is a primitive floating point value representing the
-      // time this function was called, in seconds
-
-      // Check for changes in display size
+      // Input represents the time this function was called, in seconds
       const resized = view.changed();
 
-      // Update camera dynamics
-      camMoving = camera.update(time, resized, cursor3d);
-
-      // Update cursor positions, if necessary
-      cursorChanged = cursor2d.hasChanged() || camMoving || cursor3d.wasTapped();
-      if (cursorChanged) cursor3d.update(cursor2d, camera);
+      camMoving = dynamics.update(time) || resized;
+      cursorChanged = cursor.hasChanged() || camMoving;
+      if (cursorChanged) cursor.update(camera.position(), dynamics);
 
       return camMoving;
     }
@@ -10647,11 +10484,12 @@ precision highp sampler2D;
     if (!toolTip) return;
 
     // Print altitude and lon/lat of camera
-    const alt = ball.cameraPos[2].toPrecision(5);
-    toolTip.innerHTML = alt + "km " + lonLatString(...ball.cameraPos);
+    const cameraPos = ball.cameraPos();
+    const alt = cameraPos[2].toPrecision(5);
+    toolTip.innerHTML = alt + "km " + lonLatString(...cameraPos);
 
     if (ball.isOnScene()) {
-      toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos);
+      toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos());
     }
   }
 
@@ -10735,7 +10573,7 @@ precision highp sampler2D;
     }
 
     function setPosition(marker) {
-      const visible = globe.lonLatToScreenXY(marker.screenPos, marker.lonLat);
+      const visible = globe.project(marker.screenPos, marker.lonLat);
 
       Object.assign(marker.element.style, {
         display: (visible) ? "inline-block" : "none",
@@ -10756,7 +10594,11 @@ precision highp sampler2D;
     const { globeDiv, toolTip, center, altitude, context } = params;
     var requestID;
 
-    const ball = init$1(globeDiv, center, altitude);
+    const ball = init$1({
+      display: globeDiv, 
+      position: [center[0], center[1], altitude],
+      units: "radians",
+    });
     const satView = init({
       context: context,
       globeRadius: ball.radius(),
@@ -10767,7 +10609,7 @@ precision highp sampler2D;
 
     return {
       mapLoaded: map.loaded,
-      select: (layer, dxy) => map.select(layer, ball.cursorPos, dxy),
+      select: (layer, dxy) => map.select(layer, ball.cursorPos(), dxy),
       showLayer: map.showLayer,
       hideLayer: map.hideLayer,
       getZoom: map.getZoom,
@@ -10797,8 +10639,8 @@ precision highp sampler2D;
       var moving = ball.update(time * 0.001); // Convert time from ms to seconds
 
       if (moving || map.loaded() < 1.0) {
-        map.draw(ball.cameraPos, ball.radius(), ball.view);
-        satView.draw(ball.cameraPos, ball.view.maxRay);
+        map.draw(ball.cameraPos(), ball.radius(), ball.view);
+        satView.draw(ball.cameraPos(), ball.view.maxRay);
       }
 
       if (moving) markers.update();

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -464,7 +464,7 @@ var globeletjs = (function (exports) {
     }
   }
 
-  var version = "0.0.2";
+  var version = "0.1.0";
 
   var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="sprite">
   <!--Default image for favicon-->

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -461,7 +461,7 @@ function initContext(gl) {
   }
 }
 
-var version = "0.0.2";
+var version = "0.1.0";
 
 var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="sprite">
   <!--Default image for favicon-->

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -147,7 +147,7 @@ function createUniformSetters(gl, program) {
     .filter(info => info !== undefined);
 
   const textureTypes = [gl.SAMPLER_2D, gl.SAMPLER_CUBE];
-  var textureUnit = 0;
+  let textureUnit = 0;
 
   return uniformInfo.reduce((d, info) => {
     const { name, type, size } = info;
@@ -222,7 +222,7 @@ function initProgram(gl, vertexSrc, fragmentSrc) {
   gl.linkProgram(program);
 
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-    fail$2("Unable to link the program", gl.getProgramInfoLog(program));
+    fail$3("Unable to link the program", gl.getProgramInfoLog(program));
   }
 
   const { constantSetters, constructVao } = initAttributes(gl, program);
@@ -243,13 +243,13 @@ function loadShader(gl, type, source) {
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
     const log = gl.getShaderInfoLog(shader);
     gl.deleteShader(shader);
-    fail$2("An error occured compiling the shader", log);
+    fail$3("An error occured compiling the shader", log);
   }
 
   return shader;
 }
 
-function fail$2(msg, log) {
+function fail$3(msg, log) {
   throw Error("yawgl.initProgram: " + msg + ":\n" + log);
 }
 
@@ -461,7 +461,7 @@ function initContext(gl) {
   }
 }
 
-var version = "0.0.1";
+var version = "0.0.2";
 
 var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="sprite">
   <!--Default image for favicon-->
@@ -564,7 +564,7 @@ function setParams$3(userParams) {
 // Maximum latitude for Web Mercator: 85.0113 degrees. Beware rounding!
 const maxMercLat$1 = 2.0 * Math.atan( Math.exp(Math.PI) ) - Math.PI / 2.0;
 const clipLat = (lat) => Math.min(Math.max(-maxMercLat$1, lat), maxMercLat$1);
-const degrees$1 = 180.0 / Math.PI;
+const degrees = 180.0 / Math.PI;
 
 function getProjection(units) {
   switch (units) {
@@ -582,9 +582,9 @@ function getProjection(units) {
       };
     case "degrees":
       return {
-        forward: (pt) => forward(pt.map(c => c / degrees$1)),
-        inverse: (pt) => inverse(pt).map(c => c * degrees$1),
-        scale: (pt) => scale$1(pt.map(c => c / degrees$1)),
+        forward: (pt) => forward(pt.map(c => c / degrees)),
+        inverse: (pt) => inverse(pt).map(c => c * degrees),
+        scale: (pt) => scale$1(pt.map(c => c / degrees)),
       };
     default:
       throw Error("getProjection: unknown units = " + units);
@@ -1396,7 +1396,7 @@ function initEventHandler() {
   };
 }
 
-function setParams$1(userParams) {
+function setParams$1$1(userParams) {
   const gl = userParams.context.gl;
   if (!(gl instanceof WebGLRenderingContext)) {
     fail$1("no valid WebGL context");
@@ -2586,18 +2586,18 @@ function setParams$2(userParams) {
   } = userParams;
 
   // Confirm supplied styles are all vector layers reading from the same source
-  if (!layers || !layers.length) fail("no valid array of style layers!");
+  if (!layers || !layers.length) fail$2("no valid array of style layers!");
 
   const allVectors = layers.every( l => vectorTypes.includes(l.type) );
-  if (!allVectors) fail("not all layers are vector types!");
+  if (!allVectors) fail$2("not all layers are vector types!");
 
   const sameSource = layers.every( l => l.source === layers[0].source );
-  if (!sameSource) fail("supplied layers use different sources!");
+  if (!sameSource) fail$2("supplied layers use different sources!");
 
-  if (!source) fail("parameters.source is required!");
+  if (!source) fail$2("parameters.source is required!");
 
   if (source.type === "vector" && !(source.tiles && source.tiles.length)) {
-    fail("no valid vector tile endpoints!");
+    fail$2("no valid vector tile endpoints!");
   }
 
   return {
@@ -2611,7 +2611,7 @@ function setParams$2(userParams) {
   };
 }
 
-function fail(message) {
+function fail$2(message) {
   throw Error("ERROR in tile-mixer: " + message);
 }
 
@@ -8640,7 +8640,7 @@ function distToPoint(coords, pt) {
 }
 
 function init$3(userParams) {
-  const params = setParams$1(userParams);
+  const params = setParams$1$1(userParams);
 
   // Set up dummy API
   const api = {
@@ -8699,8 +8699,7 @@ function initMap(params) {
   const framebuffer = context.initFramebuffer({ width, height });
 
   return init$3({ context, framebuffer, style, mapboxToken, units: "radians" })
-    .promise.then(api => setup$1(api, context, framebuffer.sampler))
-    .catch(console.log);
+    .promise.then(api => setup$1(api, context, framebuffer.sampler));
 }
 
 function setup$1(api, context, sampler) {
@@ -8730,7 +8729,7 @@ function setup$1(api, context, sampler) {
     const k = 1.0 / dMap;
     const zoom = Math.log2(k) - 9;
 
-    api.setCenterZoom(camPos, zoom, "radians");
+    api.setCenterZoom(camPos, zoom);
     loadStatus = api.draw();
 
     texture.scale.set(api.getScale());
@@ -8740,7 +8739,7 @@ function setup$1(api, context, sampler) {
   }
 
   function select(layer, point, radius) {
-    return api.select({ layer, point, radius, units: "radians" });
+    return api.select({ layer, point, radius });
   }
 }
 
@@ -8749,8 +8748,8 @@ function initView(porthole, fieldOfView) {
   // fieldOfView is the vertical view angle range in degrees (floating point)
 
   // Compute values for transformation between the 3D world and the 2D porthole
-  var portRect, width, height, aspect;
-  var tanFOV = Math.tan(fieldOfView * Math.PI / 180.0 / 2.0);
+  let portRect, width, height, aspect;
+  const tanFOV = Math.tan(fieldOfView * Math.PI / 180.0 / 2.0);
   const maxRay = [];
 
   computeRayParams(); // Set initial values
@@ -8797,218 +8796,20 @@ function initView(porthole, fieldOfView) {
     // right pixel -- they are one more than the clientX/Y values.
     // Thus the number of pixels in the box is given by
     //    porthole.clientWidth = rect.right - rect.left  (NO +1 !!)
-    var x = clientX - portRect.left;
-    var y = portRect.bottom - clientY - 1; // Flip sign to make +y upward
+    const x = clientX - portRect.left;
+    const y = portRect.bottom - clientY - 1; // Flip sign to make +y upward
 
     // Normalized distances from center of box. We normalize by pixel DISTANCE
     // rather than pixel count, to ensure we get -1 and +1 at the ends.
     // (Confirm by considering the 2x2 case)
-    var xratio = 2 * x / (width - 1) - 1;
-    var yratio = 2 * y / (height - 1) - 1;
+    const xratio = 2 * x / (width - 1) - 1;
+    const yratio = 2 * y / (height - 1) - 1;
 
     rayVec[0] = xratio * maxRay[0];
     rayVec[1] = yratio * maxRay[1];
     // rayVec[2] = -1.0;
     // rayVec[3] = 0.0;
     return;
-  }
-}
-
-function initCursor() {
-  // What does an animation need to know about the cursor at each frame?
-  // First, whether the user did any of the following since the last frame:
-  //  - Started new actions
-  var touchStarted = false; // Touched or clicked the element
-  var zoomStarted  = false; // Rotated mousewheel, or started two-finger touch
-  //  - Changed something
-  var moved  = false;       // Moved mouse or touch point
-  var zoomed = false;       // Rotated mousewheel, or adjusted two-finger touch
-  //  - Is potentially in the middle of something
-  var tapping = false;      // No touchEnd, and no cursor motion
-  //  - Ended actions
-  var touchEnded = false;   // mouseup or touchend/cancel/leave
-  var tapped = false;       // Completed a click or tap action
-
-  // We also need to know the current cursor position and zoom scale
-  var cursorX = 0;
-  var cursorY = 0;
-  var zscale = 1.0;
-
-  // For tap/click reporting, we need to remember where the touch started
-  var startX = 0;
-  var startY = 0;
-  // What is a click/tap and what is a drag? If the cursor moved more than
-  // this threshold between touchStart and touchEnd, it is a drag
-  const threshold = 6;
-
-  return {
-    // Methods to report local state. Return a copy to protect local values
-    touchStarted: () => touchStarted,
-    zoomStarted: () => zoomStarted,
-    moved: () => moved,
-    zoomed: () => zoomed,
-    tapped: () => tapped,
-    touchEnded: () => touchEnded,
-    hasChanged: () => (moved || zoomed || tapped),
-    zscale: () => zscale,
-    x: () => cursorX,
-    y: () => cursorY,
-
-    // Methods to update local state
-    startTouch,
-    startZoom,
-    move,
-    zoom,
-    endTouch,
-    reset,
-  };
-
-  function startTouch(evnt) {
-    cursorX = evnt.clientX;
-    cursorY = evnt.clientY;
-    touchStarted = true;
-    startX = cursorX;
-    startY = cursorY;
-    tapping = true;
-  }
-
-  function startZoom(evnt) {
-    // Store the cursor position
-    cursorX = evnt.clientX;
-    cursorY = evnt.clientY;
-    zoomStarted = true;
-    tapping = false;
-  }
-
-  function move(evnt) {
-    cursorX = evnt.clientX;
-    cursorY = evnt.clientY;
-    moved = true;
-    var dist = Math.abs(cursorX - startX) + Math.abs(cursorY - startY);
-    if (dist > threshold) tapping = false;
-  }
-
-  function zoom(scale) {
-    zscale *= scale;
-    zoomed = true;
-    tapping = false;
-  }
-
-  function endTouch() {
-    if (touchStarted) {
-      // Ending a new touch? Just ignore both // TODO: is this a good idea?
-      touchStarted = false;
-      touchEnded = false;
-    } else {
-      touchEnded = true;
-    }
-    tapped = tapping;
-    tapping = false;
-  }
-
-  function reset() {
-    touchStarted = false;
-    zoomStarted  = false;
-    moved  = false;
-    zoomed = false;
-    touchEnded = false;
-    // NOTE: we do NOT reset tapping... this could carry over to next check
-    tapped = false;
-    zscale = 1.0;
-  }
-}
-
-// Add event listeners to update the state of a cursor object
-// Input div is an HTML element on which events will be registered
-function initTouch(div) {
-  const cursor = initCursor();
-
-  // Remember the distance between two pointers
-  var lastDistance = 1.0;
-
-  // Capture the drag event so we can disable any default actions
-  div.addEventListener("dragstart", function(drag) {
-    drag.preventDefault();
-    return false;
-  }, false);
-
-  // Add mouse events
-  div.addEventListener("mousedown",   cursor.startTouch, false);
-  div.addEventListener("mousemove",   cursor.move,       false);
-  div.addEventListener("mouseup",     cursor.endTouch,   false);
-  div.addEventListener("mouseleave",  cursor.endTouch,   false);
-  div.addEventListener("wheel",       wheelZoom,         false);
-
-  // Add touch events
-  div.addEventListener("touchstart",  initTouch,       false);
-  div.addEventListener("touchmove",   moveTouch,       false);
-  div.addEventListener("touchend",    cursor.endTouch, false);
-  div.addEventListener("touchcancel", cursor.endTouch, false);
-
-  // Return a pointer to the cursor object
-  return cursor;
-
-  function initTouch(evnt) {
-    const { preventDefault, touches } = evnt;
-    preventDefault();
-    switch (touches.length) {
-      case 1:
-        cursor.startTouch(touches[0]);
-        break;
-      case 2:
-        var midpoint = getMidPoint(touches[0], touches[1]);
-        cursor.startTouch(midpoint);
-        cursor.startZoom(midpoint);
-        // Initialize the starting distance between touches
-        lastDistance = midpoint.distance;
-        break;
-      default:
-        cursor.endTouch(evnt);
-    }
-  }
-
-  function moveTouch(evnt) {
-    const { preventDefault, touches } = evnt;
-    preventDefault();
-    // NOTE: MDN says to add the touchmove handler within the touchstart handler
-    // https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events
-    switch (touches.length) {
-      case 1:
-        cursor.move(touches[0]);
-        break;
-      case 2:
-        var midpoint = getMidPoint(touches[0], touches[1]);
-        // Move the cursor to the midpoint
-        cursor.move(midpoint);
-        // Zoom based on the change in distance between the two touches
-        cursor.zoom(lastDistance / midpoint.distance);
-        // Remember the new touch distance
-        lastDistance = midpoint.distance;
-        break;
-      default:
-        return false;
-    }
-  }
-
-  // Convert a two-touch event to a single event at the midpoint
-  function getMidPoint(p0, p1) {
-    var dx = p1.clientX - p0.clientX;
-    var dy = p1.clientY - p0.clientY;
-    return {
-      clientX: p0.clientX + dx / 2,
-      clientY: p0.clientY + dy / 2,
-      distance: Math.sqrt(dx * dx + dy * dy),
-    };
-  }
-
-  function wheelZoom(turn) {
-    turn.preventDefault();
-    cursor.startZoom(turn);
-    // We ignore the dY from the browser, since it may be arbitrarily scaled
-    // based on screen resolution or other factors. We keep only the sign.
-    // See https://github.com/Leaflet/Leaflet/issues/4538
-    var zoomScale = 1.0 + 0.2 * Math.sign(turn.deltaY);
-    cursor.zoom(zoomScale);
   }
 }
 
@@ -9062,37 +8863,6 @@ function length(a) {
   var y = a[1];
   var z = a[2];
   return Math.hypot(x, y, z);
-}
-/**
- * Set the components of a vec3 to the given values
- *
- * @param {vec3} out the receiving vector
- * @param {Number} x X component
- * @param {Number} y Y component
- * @param {Number} z Z component
- * @returns {vec3} out
- */
-
-function set(out, x, y, z) {
-  out[0] = x;
-  out[1] = y;
-  out[2] = z;
-  return out;
-}
-/**
- * Adds two vec3's
- *
- * @param {vec3} out the receiving vector
- * @param {ReadonlyVec3} a the first operand
- * @param {ReadonlyVec3} b the second operand
- * @returns {vec3} out
- */
-
-function add(out, a, b) {
-  out[0] = a[0] + b[0];
-  out[1] = a[1] + b[1];
-  out[2] = a[2] + b[2];
-  return out;
 }
 /**
  * Subtracts vector b from vector a
@@ -9260,59 +9030,108 @@ function transformMat3(out, a, m) {
   };
 })();
 
+function initRayGun(M, meanRadius) {
+  // All method arguments are vec3s in ECEF coordinates
+  return { shoot: shootEllipsoid, findHorizon };
+
+  function shootEllipsoid(intersection, camera, rayVec) {
+    // Input rayVec: direction of a ray shot from camera
+    // Outputs position of the intersection of the ray with the ellipsoid
+
+    // Math: solving for values t where || M (camera + t*rayVec) || = 1,
+    const mCam = M(camera);
+    const mRay = M(rayVec);
+
+    // We now have <mRay,mRay>*t^2 + 2*<mRay,mCam>*t + <mCam,mCam> - 1 = 0
+    const a = dot(mRay, mRay);
+    const b = 2.0 * dot(mRay, mCam);
+    const c = dot(mCam, mCam) - 1.0;
+    const discriminant = b ** 2 - 4 * a * c;
+
+    const intersected = (discriminant >= 0);
+
+    // There are generally 2 intersections. We want the closer one, with
+    // smallest positive t. (b < 0, if ray is back from camera to ellipsoid)
+    // If no intersection, find the point on the ray that comes closest to the
+    // unit sphere: minimize a*t^2 + b*t + c (get zero of derivative)
+    // NOTE: NOT the closest point on the ellipsoid! And NOT on the horizon!
+    const t = (intersected)
+      ? (-b - Math.sqrt(discriminant)) / (2.0 * a)
+      : -0.5 * b / a;
+
+    // NOTE: rayVec is actually a vec4
+    scaleAndAdd(intersection, camera, rayVec, t);
+    return intersected; // Indicates whether the ray did in fact hit
+  }
+
+  function findHorizon(horizon, camera, rayVec) {
+    // Find the point on the horizon under rayvec.
+    // We first adjust rayVec to point it toward the horizon, and then
+    // re-shoot the ellipsoid with the corrected ray
+    const dRay = new Float64Array(3);
+
+    // 1. Find the component of rayVec parallel to camera direction
+    normalize(dRay, camera); // Unit vector along camera direction
+    const paraLength = dot(dRay, rayVec);
+    scale(dRay, dRay, paraLength);
+
+    // 2. Find the component perpendicular to camera direction
+    subtract(dRay, rayVec, dRay);
+    const perpLength = length(dRay);
+    if (perpLength == 0) return false; // No solution if ray is vertical
+
+    // 3. Find the error of the length of the perpendicular component
+    const sinAlpha = meanRadius / length(camera); // sin(angle to horizon)
+    const tanAlpha = sinAlpha / Math.sqrt(1.0 - sinAlpha * sinAlpha);
+    const dPerp = -paraLength * tanAlpha - perpLength;
+
+    // 4. Find the corrected rayVec
+    scaleAndAdd(dRay, rayVec, dRay, dPerp / perpLength);
+
+    // 5. Re-shoot the ellipsoid with the corrected rayVec
+    shootEllipsoid(horizon, camera, dRay);
+    return true;
+  }
+}
+
 function initEcefToLocalGeo() {
-  const { cos, sin, sqrt } = Math;
-  var sinLon, cosLon, sinLat, cosLat;
+  const { cos, sin, hypot } = Math;
   const toENU = new Float64Array(9);
 
-  return ecefToDeltaLonLatAlt;
-
-  function ecefToDeltaLonLatAlt( delta, diff, anchor, viewPos ) {
-    // Inputs are pointers to vec3s. anchor is a position in ECEF coordinates.
-    // diff represents a differential change (e.g. motion?) near anchor.
+  return function ecefToDeltaLonLatAlt(delta, diff, anchor, viewPos) {
+    // Inputs are in ECEF coords. viewPos represents the position of the model
+    //   coordinates relative to the view coordinates.
+    // Input diff represents a differential change (e.g. motion?) near anchor
     // Output delta will be the corresponding differentials in lon/lat/alt
-    // viewPos represents the position of the model coordinates (ECEF) relative
-    // to the view coordinates.    WARNING: diff will be overwritten
+
+    // 0. Compute sines and cosines of longitude and latitude at anchor, which
+    // is a surface normal on an ellipsoid (or an ECEF position on a sphere)
+    const [x, y, z] = anchor;
+    const p = hypot(x, z);
+    const cosLon = (p > 0) ? z / p : 0.0;
+    const sinLon = (p > 0) ? x / p : 0.0;
+    const r = hypot(x, y, z);
+    const cosLat = p / r;
+    const sinLat = y / r;
 
     // 1. Transform to local East-North-Up coordinates at the anchor location
-    setupENU( anchor );
-    transformMat3( diff, diff, toENU );
+    setupENU(cosLon, sinLon, cosLat, sinLat);
+    transformMat3(delta, diff, toENU);
 
     // 2. Convert horizontal component to changes in longitude, latitude
-    const r = length(anchor);
-    delta[0] = diff[0] / r / (cosLat + 0.0001); // +0.0001 avoids /0
-    delta[1] = diff[1] / r;
-    delta[2] = diff[2];
+    delta[0] = delta[0] / r / (cosLat + 0.0001); // +0.0001 avoids /0
+    delta[1] = delta[1] / r;
 
     // 3. Latitudinal change is a rotation about an axis in the x-z plane, with
     // direction vec3.cross(anchor,North), or -East. We only want the component
     // rotating about the x-axis in view coordinates.
     delta[1] *= (cos(viewPos[0]) * cosLon + sin(viewPos[0]) * sinLon);
-    return;
-  }
+  };
 
-  function setupENU( normal ) {
-    // Setup the matrix to rotate from global Earth-Centered-Earth-Fixed
-    // to local East-North-Up coordinates. Assumptions for input ECEF:
-    //    y-axis is the polar axis
-    //   +z-axis points toward latitude = longitude = 0.
-    // Input normal is an ellipsoid surface normal at the desired ENU origin
-
-    // Update sines and cosines of the latitude and longitude of the normal
-    const p2 = normal[0] ** 2 + normal[2] ** 2;
-    const p = sqrt(p2);
-    if (p > 0) {
-      sinLon = normal[0] / p;
-      cosLon = normal[2] / p;
-    } else {
-      sinLon = 0.0;
-      cosLon = 0.0;
-    }
-    const r = sqrt(p2 + normal[1] ** 2);
-    sinLat = normal[1] / r;
-    cosLat = p / r;
-
-    // Build matrix. Follows Widnal & Peraire (MIT) p.7, with the axes renamed:
+  function setupENU(cosLon, sinLon, cosLat, sinLat) {
+    // Build matrix to rotate from global Earth-Centered-Earth-Fixed
+    // to local East-North-Up coordinates.
+    // Follows Widnal & Peraire (MIT) p.7, with axes renamed:
     //   z -> y, y -> x, x -> z
     // Using OpenGL COLUMN-MAJOR format!!
     toENU[0] =  cosLon;
@@ -9330,12 +9149,12 @@ function initEcefToLocalGeo() {
     // Elements (0, 3, 6) = unit vector in East direction
     // Elements (1, 4, 7) = unit vector in North direction
     // Elements (2, 5, 8) = unit vector in Up direction
-    return;
   }
 }
 
 function initEllipsoid() {
-  const { atan2, sin, cos, sqrt } = Math;
+  const { atan2, sin, cos, sqrt, hypot } = Math;
+
   // Store ellipsoid parameters
   const semiMajor = 6371.0;  // kilometers
   const semiMinor = 6371.0;  // kilometers
@@ -9343,136 +9162,119 @@ function initEllipsoid() {
   // https://en.wikipedia.org/wiki/Earth_radius#Mean_radius
   const meanRadius = (2.0 * semiMajor + semiMinor) / 3.0;
 
-  // Working vectors for shootEllipsoid, findHorizon
-  const mCam = new Float64Array(3);
-  const mRay = new Float64Array(3);
-  const dRay = new Float64Array(3);
+  // M: matrix to scale ellipsoid to unit sphere. The ellipsoid is
+  // aligned with the coordinate axes, so we can store only the diagonal
+  const Mdiag = [semiMajor, semiMinor, semiMajor];
+  const M = vec => vec.map((c, i) => c / Mdiag[i]);
+
+  const { shoot, findHorizon } = initRayGun(M, meanRadius);
 
   return {
     meanRadius: () => meanRadius,
     ecef2geocentric,
     ecefToDeltaLonLatAlt: initEcefToLocalGeo(),
     geodetic2ecef,
-    shoot: shootEllipsoid,
+    shoot,
     findHorizon,
   };
 
   function ecef2geocentric(gcPos, ecefPos) {
-    // Output gcPos is a pointer to a 3-element array, containing geocentric
-    //  longitude & latitude (radians) and altitude (meters) coordinates
-    // Input ecefPos is a pointer to a 3-element array, containing earth-
-    //  centered earth-fixed x,y,z coordinates in the WebGL axis definition
+    // Input earth-centered earth-fixed coords are in WebGL axis definition
+    const [x, y, z] = ecefPos;
 
-    // Note: order of calculations is chosen to allow calls with same array
-    // as input & output (gcPos, ecefPos point to same array)
-
-    // Compute squared distance from polar axis
-    const p2 = ecefPos[0] ** 2 + ecefPos[2] ** 2;
-
-    gcPos[0] = atan2(ecefPos[0], ecefPos[2]);     // Longitude
-    gcPos[1] = atan2(ecefPos[1], sqrt(p2));  // Latitude
-
-    // NOTE: this "altitude" is distance from SPHERE, not ellipsoid
-    gcPos[2] = sqrt(p2 + ecefPos[1] ** 2) - meanRadius; // Altitude
-    return;
+    // Output coords are geocentric: valid for a SPHERE, not an ellipsoid
+    gcPos[0] = atan2(x, z); // Longitude (radians)
+    gcPos[1] = atan2(y, hypot(x, z)); // Latitude (radians)
+    gcPos[2] = hypot(x, y, z) - meanRadius; // Altitude (kilometers)
   }
 
   function geodetic2ecef(ecef, geodetic) {
-    // Output ecef is a pointer to a 3-element array containing X,Y,Z values
-    //   of the point in earth-centered earth-fixed (ECEF) coordinates
-    // Input geodetic is a pointer to a 3-element array, containing
-    //   longitude & latitude (in radians) and altitude (in meters)
+    // Input geodetic units: [radians, radians, kilometers]
+    const [lon, lat, alt] = geodetic;
 
     // Start from prime vertical radius of curvature -- see
     // https://en.wikipedia.org/wiki/Geographic_coordinate_conversion
-    const sinLat = sin( geodetic[1] );
-    const primeVertRad = semiMajor / sqrt( 1.0 - e2 * sinLat ** 2 );
+    const sinLat = sin(lat);
+    const primeVertRad = semiMajor / sqrt(1.0 - e2 * sinLat ** 2);
     // Radial distance from y-axis:
-    const p = (primeVertRad + geodetic[2]) * cos(geodetic[1]);
+    const p = (primeVertRad + alt) * cos(lat);
 
-    // Compute ECEF position
-    ecef[0] = p * sin(geodetic[0]);
-    ecef[1] = (primeVertRad + geodetic[2]) * sinLat * (1.0 - e2);
-    ecef[2] = p * cos(geodetic[0]);
-    return;
+    // Compute earth-centered earth-fixed (ECEF) coordinates
+    ecef[0] = p * sin(lon);
+    ecef[1] = (primeVertRad + alt) * sinLat * (1.0 - e2);
+    ecef[2] = p * cos(lon);
+  }
+}
+
+function checkCoords(p, n) {
+  const isArray = Array.isArray(p) ||
+    (ArrayBuffer.isView(p) && !(p instanceof DataView));
+  return isArray && p.length >= n &&
+    p.slice(0, n).every(Number.isFinite);
+}
+
+function getUnitConversion(units) {
+  // Internally, spinning-ball assumes geodetic coordinates in these units:
+  //   [longitude (radians), latitude (radians), altitude (kilometers)]
+  // Externally, the user may want longitude and latitude in degrees.
+  // Construct the functions that convert user inputs to internal coordinates,
+  // and invert internal coordinates to the user's units
+  const uPerRad = (units === "degrees")
+    ? 180.0 / Math.PI
+    : 1.0;
+
+  return {
+    convert: c => new Float64Array([c[0] / uPerRad, c[1] / uPerRad, c[2]]),
+    invert: c => new Float64Array([c[0] * uPerRad, c[1] * uPerRad, c[2]]),
+  };
+}
+
+function setParams$1(params) {
+  const { PI } = Math;
+
+  // TODO: Get user-supplied semiMinor & semiMajor axes?
+  const ellipsoid = initEllipsoid();
+
+  const {
+    display,
+    units: userUnits = "degrees",
+    position = [0.0, 0.0, ellipsoid.meanRadius * 4.0],
+    minHeight = ellipsoid.meanRadius() * 0.00001,
+    maxHeight = ellipsoid.meanRadius() * 8.0,
+  } = params;
+
+  if (!(display instanceof Element)) fail("missing display element");
+
+  if (!["degrees", "radians"].includes(userUnits)) fail("invalid units");
+  const units = getUnitConversion(userUnits);
+
+  // minHeight, maxHeight must be Numbers, positive and not too big
+  const heights = [minHeight, maxHeight];
+  if (!heights.every(h => Number.isFinite(h) && h > 0)) {
+    fail("minHeight, maxHeight must be Numbers > 0");
+  } else if (heights.some(h => h > ellipsoid.meanRadius() * 100000.0)) {
+    fail("minHeight, maxHeight must be somewhere below Jupiter");
   }
 
-  function shootEllipsoid(intersection, camera, rayVec) {
-    // Inputs camera, rayVec are pointers to vec3s indicating the
-    //   position of the camera and the direction of a ray shot from the camera,
-    //   both in earth-centered earth-fixed (ECEF) coordinates
-    // Output intersection is a pointer to a vec3 in ECEF coordinates indicating
-    //   the position of the intersection of the ray with the ellipsoid
-    // Return value indicates whether the ray did in fact intersect the spheroid
+  // initialPosition must be a valid coordinate in the given units
+  if (!checkCoords(position, 3)) fail("invalid center array");
+  const initialPosition = units.convert(position);
+  const [lon, lat, alt] = initialPosition;
+  const outOfRange =
+    lon < -PI || lon > PI ||
+    lat < -PI / 2 || lat > PI / 2 ||
+    alt < minHeight || alt > maxHeight;
+  if (outOfRange) fail ("initial position out of range");
 
-    // Math: solving for values t where || M (camera + t*rayVec) || = 1,
-    //  where M is the matrix that scales the ellipsoid to the unit sphere,
-    //  i.e., for P = (x,y,z), MP = (x/a, y/b, z/c). Since M is diagonal
-    //  (ellipsoid aligned along coordinate axes) we just scale each coordinate.
-    mCam.set([
-      camera[0] / semiMajor,
-      camera[1] / semiMinor,
-      camera[2] / semiMajor
-    ]);
-    mRay.set([
-      rayVec[0] / semiMajor,
-      rayVec[1] / semiMinor,
-      rayVec[2] / semiMajor
-    ]);
+  return {
+    ellipsoid, display, units, initialPosition, minHeight, maxHeight,
+    view: initView(display, 25.0), // Computes ray params at point on display
+  };
+}
 
-    // We now have <mRay,mRay>*t^2 + 2*<mRay,mCam>*t + <mCam,mCam> - 1 = 0
-    const a = dot(mRay, mRay);
-    const b = 2.0 * dot(mRay, mCam);
-    const c = dot(mCam, mCam) - 1.0;
-    const discriminant = b ** 2 - 4 * a * c;
-
-    const intersected = (discriminant >= 0);
-    var t;
-    if (intersected) {
-      // We want the closest intersection, with smallest positive t
-      // We assume b < 0, if ray is pointing back from camera to ellipsoid
-      t = (-b - sqrt(discriminant)) / (2.0 * a);
-    } else {
-      // Find the point that comes closest to the unit sphere
-      //   NOTE: this is NOT the closest point to the ellipsoid!
-      //   And it is not even the point on the horizon! It is closer...
-      // Minimize a*t^2 + b*t + c, by finding the zero of the derivative
-      t = -0.5 * b / a;
-    }
-
-    // NOTE: rayVec is actually a vec4
-    scaleAndAdd(intersection, camera, rayVec, t);
-    return intersected;
-  }
-
-  function findHorizon(horizon, camera, rayVec) {
-    // Find the point on the horizon under rayvec.
-    // We first adjust rayVec to point it toward the horizon, and then
-    // re-shoot the ellipsoid with the corrected ray
-
-    // 1. Find the component of rayVec parallel to camera direction
-    normalize(dRay, camera); // Unit vector along camera direction
-    const paraLength = dot(dRay, rayVec);
-    scale( dRay, dRay, paraLength );
-
-    // 2. Find the component perpendicular to camera direction
-    subtract( dRay, rayVec, dRay );
-    const perpLength = length(dRay);
-    if (perpLength == 0) return false; // No solution if ray is vertical
-
-    // 3. Find the error of the length of the perpendicular component
-    const sinAlpha = meanRadius / length(camera); // sin(angle to horizon)
-    const tanAlpha = sinAlpha / sqrt(1.0 - sinAlpha * sinAlpha);
-    const dPerp = -paraLength * tanAlpha - perpLength;
-
-    // 4. Find the corrected rayVec
-    scaleAndAdd(dRay, rayVec, dRay, dPerp / perpLength);
-
-    // 5. Re-shoot the ellipsoid with the corrected rayVec
-    shootEllipsoid(horizon, camera, dRay);
-
-    return true;
-  }
+function fail(message) {
+  // TODO: Should some errors be RangeErrors or TypeErrors instead?
+  throw Error("spinning-ball: " + message);
 }
 
 /**
@@ -9644,14 +9446,12 @@ function initECEF(ellipsoid, initialPos) {
   // coordinates and a rotation matrix
   // These are suitable for rendering Relative To Eye (RTE), as described in
   // P Cozzi, 3D Engine Design for Virtual Globes, www.virtualglobebook.com
+  const { min, max, PI } = Math;
   const position = new Float64Array([0.0, 0.0, 0.0, 1.0]);
   const rotation = create$1();  // Note: single precision!! (Float32Array)
   const inverse  = create$1();
 
-  const halfPi = Math.PI / 2.0;
-
-  // Set initial values
-  update(initialPos);
+  update(initialPos); // Set initial values
 
   return {
     position, // WARNING: Exposes local array to changes from outside
@@ -9662,25 +9462,278 @@ function initECEF(ellipsoid, initialPos) {
 
   function update(geodetic) {
     // Limit rotation around screen x-axis to keep global North pointing up
-    geodetic[1] = Math.min(Math.max(-halfPi, geodetic[1]), halfPi);
+    geodetic[1] = min(max(-PI / 2.0, geodetic[1]), PI / 2.0);
     // Avoid accumulation of large values in longitude
-    if (geodetic[0] >  Math.PI) geodetic[0] -= 2.0 * Math.PI;
-    if (geodetic[0] < -Math.PI) geodetic[0] += 2.0 * Math.PI;
+    if (geodetic[0] >  PI) geodetic[0] -= 2.0 * PI;
+    if (geodetic[0] < -PI) geodetic[0] += 2.0 * PI;
 
     // Compute ECEF coordinates. NOTE WebGL coordinate convention:
     // +x to right, +y to top of screen, and +z into the screen
-    ellipsoid.geodetic2ecef( position, geodetic );
+    ellipsoid.geodetic2ecef(position, geodetic);
 
     // Rotation: y first, so it will be left of x operator in final matrix
     // (gl-matrix library 'post-multplies' by each new matrix)
     // Positive angles about Y are towards the +X axis, or East longitude.
-    fromYRotation( rotation, geodetic[0] );
+    fromYRotation(rotation, geodetic[0]);
     // Positive angles about X are towards the -Y axis!
     // (from Y to Z, and Z to -Y). But geodetic[1] is a latitude, toward N
-    rotateX( rotation, rotation, -geodetic[1] );
+    rotateX(rotation, rotation, -geodetic[1]);
 
     // The inverse of a rotation matrix is its transpose
-    transpose( inverse, rotation );
+    transpose(inverse, rotation);
+  }
+}
+
+function initCamera(params) {
+  const { view, ellipsoid, initialPosition } = params;
+  const rayVec = new Float64Array(3);
+  const ecefTmp = new Float64Array(3);
+
+  // [longitude (radians), latitude (radians), altitude (kilometers)]
+  const position = new Float64Array(initialPosition);
+
+  const ecef = initECEF(ellipsoid, position);
+
+  return {
+    position: () => position.slice(),
+    ecefPos: ecef.position, // WARNING: exposed to changes from outside!
+    rotation: ecef.rotation,
+
+    project,
+    ecefToScreenRay,
+    update,
+  };
+
+  function update(dPos) {
+    if (dPos.every(c => c == 0.0)) return;
+    position.set(position.map((c, i) => c + dPos[i]));
+    ecef.update(position);
+  }
+
+  function project(xy, geodetic) {
+    // Project a geodetic position on the ellipsoid (lon, lat, alt)
+    //  to a position on the display (x, y in pixels)
+    ellipsoid.geodetic2ecef(ecefTmp, geodetic);
+    const visible = ecefToScreenRay(rayVec, ecefTmp);
+
+    xy[0] = view.width() * (1 + rayVec[0] / view.rightEdge()) / 2;
+    xy[1] = view.height() * (1 - rayVec[1] / view.topEdge()) / 2;
+    return visible;
+  }
+
+  function ecefToScreenRay(screenRay, ecefPoint) {
+    // Find the screenRay (from camera position) that intersects ecefPoint
+
+    // Translate to camera position
+    subtract(rayVec, ecefPoint, ecef.position);
+    // rayVec now points from camera to ecef. The sign of the
+    // dot product tells us whether it is beyond the horizon
+    const visible = dot(rayVec, ecefPoint) < 0;
+
+    // Rotate to camera orientation
+    transformMat4$1(screenRay, rayVec, ecef.inverse);
+
+    // Normalize to z = -1
+    screenRay[0] /= -screenRay[2];
+    screenRay[1] /= -screenRay[2];
+    screenRay[2] = -1.0;
+
+    return visible;
+  }
+}
+
+function initCursor() {
+  // What does an animation need to know about the cursor at each frame?
+  // First, whether the user did any of the following since the last frame:
+  //  - Started new actions
+  let touchStarted = false; // Touched or clicked the element
+  let zoomStarted  = false; // Rotated mousewheel, or started two-finger touch
+  //  - Changed something
+  let moved  = false;       // Moved mouse or touch point
+  let zoomed = false;       // Rotated mousewheel, or adjusted two-finger touch
+  //  - Is potentially in the middle of something
+  let tapping = false;      // No touchEnd, and no cursor motion
+  //  - Ended actions
+  let touchEnded = false;   // mouseup or touchend/cancel/leave
+  let tapped = false;       // Completed a click or tap action
+
+  // We also need to know the current cursor position and zoom scale
+  let cursorX = 0;
+  let cursorY = 0;
+  let zscale = 1.0;
+
+  // For tap/click reporting, we need to remember where the touch started
+  let startX = 0;
+  let startY = 0;
+  // What is a click/tap and what is a drag? If the cursor moved more than
+  // this threshold between touchStart and touchEnd, it is a drag
+  const threshold = 6;
+
+  return {
+    // Methods to report local state. Return a copy to protect local values
+    touchStarted: () => touchStarted,
+    zoomStarted: () => zoomStarted,
+    moved: () => moved,
+    zoomed: () => zoomed,
+    tapped: () => tapped,
+    touchEnded: () => touchEnded,
+    hasChanged: () => (moved || zoomed || tapped),
+    zscale: () => zscale,
+    x: () => cursorX,
+    y: () => cursorY,
+
+    // Methods to update local state
+    startTouch,
+    startZoom,
+    move,
+    zoom,
+    endTouch,
+    reset,
+  };
+
+  function startTouch(evnt) {
+    cursorX = evnt.clientX;
+    cursorY = evnt.clientY;
+    touchStarted = true;
+    startX = cursorX;
+    startY = cursorY;
+    tapping = true;
+  }
+
+  function startZoom(evnt) {
+    // Store the cursor position
+    cursorX = evnt.clientX;
+    cursorY = evnt.clientY;
+    zoomStarted = true;
+    tapping = false;
+  }
+
+  function move(evnt) {
+    cursorX = evnt.clientX;
+    cursorY = evnt.clientY;
+    moved = true;
+    const dist = Math.abs(cursorX - startX) + Math.abs(cursorY - startY);
+    if (dist > threshold) tapping = false;
+  }
+
+  function zoom(scale) {
+    zscale *= scale;
+    zoomed = true;
+    tapping = false;
+  }
+
+  function endTouch() {
+    if (touchStarted) {
+      // Ending a new touch? Just ignore both // TODO: is this a good idea?
+      touchStarted = false;
+      touchEnded = false;
+    } else {
+      touchEnded = true;
+    }
+    tapped = tapping;
+    tapping = false;
+  }
+
+  function reset() {
+    touchStarted = false;
+    zoomStarted  = false;
+    moved  = false;
+    zoomed = false;
+    touchEnded = false;
+    // NOTE: we do NOT reset tapping... this could carry over to next check
+    tapped = false;
+    zscale = 1.0;
+  }
+}
+
+function initTouch(div) {
+  // Add event listeners to update the state of a cursor object
+  // Input div is an HTML element on which events will be registered
+  const cursor = initCursor();
+
+  // Remember the distance between two pointers
+  let lastDistance = 1.0;
+
+  div.addEventListener("dragstart", d => d.preventDefault(), false);
+
+  // Add mouse events
+  div.addEventListener("mousedown",   cursor.startTouch, false);
+  div.addEventListener("mousemove",   cursor.move,       false);
+  div.addEventListener("mouseup",     cursor.endTouch,   false);
+  div.addEventListener("mouseleave",  cursor.endTouch,   false);
+  div.addEventListener("wheel",       wheelZoom,         false);
+
+  // Add touch events
+  div.addEventListener("touchstart",  initTouch,       false);
+  div.addEventListener("touchmove",   moveTouch,       false);
+  div.addEventListener("touchend",    cursor.endTouch, false);
+  div.addEventListener("touchcancel", cursor.endTouch, false);
+
+  return cursor;
+
+  function initTouch(evnt) {
+    const { touches } = evnt;
+    evnt.preventDefault();
+    switch (touches.length) {
+      case 1:
+        cursor.startTouch(touches[0]);
+        break;
+      case 2: {
+        const midpoint = getMidPoint(touches[0], touches[1]);
+        cursor.startTouch(midpoint);
+        cursor.startZoom(midpoint);
+        // Initialize the starting distance between touches
+        lastDistance = midpoint.distance;
+        break;
+      }
+      default:
+        cursor.endTouch(evnt);
+    }
+  }
+
+  function moveTouch(evnt) {
+    const { touches } = evnt;
+    evnt.preventDefault();
+    // NOTE: MDN says to add the touchmove handler within the touchstart handler
+    // https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events
+    switch (touches.length) {
+      case 1:
+        cursor.move(touches[0]);
+        break;
+      case 2: {
+        const midpoint = getMidPoint(touches[0], touches[1]);
+        // Move the cursor to the midpoint
+        cursor.move(midpoint);
+        // Zoom based on the change in distance between the two touches
+        cursor.zoom(lastDistance / midpoint.distance);
+        // Remember the new touch distance
+        lastDistance = midpoint.distance;
+        break;
+      }
+      default:
+        return false;
+    }
+  }
+
+  // Convert a two-touch event to a single event at the midpoint
+  function getMidPoint(p0, p1) {
+    const dx = p1.clientX - p0.clientX;
+    const dy = p1.clientY - p0.clientY;
+    return {
+      clientX: p0.clientX + dx / 2,
+      clientY: p0.clientY + dy / 2,
+      distance: Math.hypot(dx, dy),
+    };
+  }
+
+  function wheelZoom(turn) {
+    turn.preventDefault();
+    cursor.startZoom(turn);
+    // We ignore the dY from the browser, since it may be arbitrarily scaled
+    // based on screen resolution or other factors. We keep only the sign.
+    // See https://github.com/Leaflet/Leaflet/issues/4538
+    const zoomScale = 1.0 + 0.2 * Math.sign(turn.deltaY);
+    cursor.zoom(zoomScale);
   }
 }
 
@@ -9775,434 +9828,63 @@ function transformMat4(out, a, m) {
   };
 })();
 
-function initEdgePoints(ellipsoid, camPos, camRot, screen) {
-  // Allocate working arrays and variables
-  const rayVec = new Float64Array([0.0, 0.0, -1.0, 0.0]);
-  const camRay = new Float64Array(4);
-  const rayHit = new Float64Array(3);
-  var tanX, tanY;
+function initCursor2d(params, camera) {
+  const { display, view, ellipsoid } = params;
 
-  // Construct a list of points around the screen edges
-  const screenPoints = [
-    [-1.0, -1.0], // Bottom left
-    [-0.5, -1.0],
-    [0.0, -1.0], // Bottom center
-    [0.5, -1.0],
-    [1.0, -1.0], // Bottom right
-    [1.0, -0.5],
-    [1.0,  0.0], // Right center
-    [1.0,  0.5],
-    [1.0,  1.0], // Top right
-    [0.5,  1.0],
-    [0.0,  1.0], // Top center
-    [-0.5,  1.0],
-    [-1.0,  1.0], // Top left
-    [-1.0,  0.5],
-    [-1.0,  0.0], // Left center
-    [-1.0, -0.5],
-    [-1.0, -1.0], // Loop back to bottom left
-  ];
+  const cursor2d = initTouch(display);
 
-  // An edgePoint is the point on the ellipsoid visible from screenPoint
-  const edgePoints = screenPoints.map(() => []);
-  update();
+  const screenRay = new Float64Array([0.0, 0.0, -1.0, 0.0]);
+  const ecefRay = new Float64Array(4);
+  const cursorLonLat = new Float64Array(3);
 
-  return {
-    lonLats: edgePoints,  // WARNING: exposed to updates from outside!
-    update,
-  };
+  function project(cursorPosition) {
+    // Project a cursor position on the display (x, y in pixels)
+    //  to an ECEF coordinate on the ellipsoid
 
-  function update() {
-    // Update the view angles at the screen edges
-    tanX = screen.rightEdge();
-    tanY = screen.topEdge();
+    view.getRayParams(screenRay, cursor2d.x(), cursor2d.y());
+    transformMat4(ecefRay, screenRay, camera.rotation);
+    // NOTE: cursorPosition will be overwritten!
+    const onScene = ellipsoid.shoot(cursorPosition, camera.ecefPos, ecefRay);
 
-    // Find the ellipsoid intersection at each screen point
-    screenPoints.forEach(shoot);
+    // Convert to longitude/latitude/altitude
+    if (onScene) ellipsoid.ecef2geocentric(cursorLonLat, cursorPosition);
+
+    return onScene;
   }
 
-  function shoot(screenPos, index) {
-    // Construct the ray vector
-    rayVec[0] = screenPos[0] * tanX;
-    rayVec[1] = screenPos[1] * tanY;
-    // Rotate to model coordinates (Earth-Centered Earth-Fixed)
-    transformMat4(camRay, rayVec, camRot);
-
-    // Find intersection of ray with ellipsoid
-    var hit = ellipsoid.shoot(rayHit, camPos, camRay);
-    // If it didn't intersect, find the nearest point on the horizon
-    if (!hit) ellipsoid.findHorizon(rayHit, camPos, camRay);
-
-    // Convert to longitude/latitude. NOTE: geocentric!!
-    ellipsoid.ecef2geocentric(edgePoints[index], rayHit);
-  }
+  return Object.assign(cursor2d, { project, screenRay, cursorLonLat });
 }
 
-function updateOscillator(pos, vel, ext, w0, dt, i1, i2) {
-  // Update position and velocity for a critically damped oscillator, following
-  // http://mathworld.wolfram.com/CriticallyDampedSimpleHarmonicMotion.html
+function initCursor3d(params, camera) {
+  const { initialPosition, minHeight, maxHeight } = params;
 
-  // Inputs/outputs pos, vel are pointers to arrays
-  // Inputs w0, t are primitive floating point values, indicating the
-  //   natural frequency of the oscillator and the time step
-  // Inputs i1, i2 are primitive integer values, indicating components to update
-
-  var expTerm = Math.exp( -w0 * dt );
-
-  for (let i = i1; i <= i2; i++) {
-    var tmp = (vel[i] + w0 * ext[i]) * dt * expTerm;
-    vel[i] += (expTerm - 1) * vel[i] - w0 * tmp;
-    pos[i] += (expTerm - 1) * ext[i] + tmp;
-  }
-  return;
-}
-
-// initZoom: Update camera altitude based on target set by mouse wheel events
-//  or two-finger pinch movements
-function initZoom( ellipsoid ) {
-  const w0 = 14.14; // Natural frequency of oscillator
-  const minVelocity = 0.001;
-  const maxRotation = 0.15;
-
-  // NOTE: everything below ASSUMES mass = 1
-  var minEnergy = 0.5 * minVelocity * minVelocity;
-  var extension, kineticE, potentialE;
-  const dPos = new Float64Array(3);
-
-  return function( position, velocity, cursor3d, deltaTime, track ) {
-    // Input cursor3d is a pointer to an object
-    // Inputs position, velocity are pointers to 3-element arrays
-    // Input deltaTime is a primitive floating point value
-
-    var targetHeight = cursor3d.zoomTarget();
-
-    // Save old altitude
-    var oldAltitude = position[2];
-
-    dPos[2] = position[2] - targetHeight;
-    updateOscillator(position, velocity, dPos, w0, deltaTime, 2, 2);
-
-    if (track) {
-      // Adjust rotation to keep zoom location fixed on screen
-      dPos.set(position);
-      dragonflyStalk(dPos, cursor3d.zoomRay, cursor3d.zoomPosition, ellipsoid);
-      // Restrict size of rotation in one time step
-      subtract(dPos, dPos, position);
-      var limited = limitRotation(dPos, maxRotation);
-      add(position, position, dPos);
-    }
-
-    // Scale rotational velocity by the ratio of the height change
-    var heightScale = position[2] / oldAltitude;
-    velocity[0] *= heightScale;
-    velocity[1] *= heightScale;
-
-    if (cursor3d.isClicked() || limited) return;
-
-    // Stop if we are already near steady state
-    kineticE = 0.5 * velocity[2] ** 2;
-    extension = position[2] - targetHeight;
-    potentialE = 0.5 * (w0 * extension) ** 2;
-    if (kineticE + potentialE < minEnergy * targetHeight) {
-      targetHeight = position[2];
-      velocity[2] = 0.0;
-      cursor3d.stopZoom();
-    }
-    return;
-  };
-}
-
-function limitRotation(dPos, maxRotation) {
-  // Input dPos is a pointer to a 2-element array containing lon, lat changes
-  // maxRotation is a primitive floating point value
-
-  // Check for longitude value crossing antimeridian
-  if (dPos[0] >  Math.PI) dPos[0] -= 2.0 * Math.PI;
-  if (dPos[0] < -Math.PI) dPos[0] += 2.0 * Math.PI;
-
-  if (Math.abs(dPos[0]) > maxRotation) {
-    var tmp = Math.min(Math.max(-maxRotation, dPos[0]), maxRotation) / dPos[0];
-    dPos[0] *= tmp;
-    dPos[1] *= tmp;
-    return true;
-  }
-  return false;
-}
-
-// Given a 3D scene coordinate over which a zoom action was initiated,
-// and a distance between the screen and the center of the 3D scene,
-// compute the rotations required to align the 3D coordinate along
-// the original screen ray.  See
-// https://en.wikipedia.org/wiki/Dragonfly#Motion_camouflage
-// TODO: Clean this up. Just use difference of lat/lon under ray?
-function dragonflyStalk(outRotation, ray, scenePos, ellipsoid) {
-  // Output outRotation is a pointer to a vec3
-  // Input ray is a pointer to a vec3
-  // Input scenePos is a pointer to a 3D cursor object
-
-  // Find the ray-sphere intersection in unrotated model space coordinates
-  var target = new Float64Array(3);
-  var unrotatedCamPos = [0.0, 0.0, outRotation[2] + length(scenePos)];
-  var onEllipse = ellipsoid.shoot(target, unrotatedCamPos, ray);
-  if (!onEllipse) return; // No intersection!
-
-  // Find the rotation about the y-axis required to bring scene point into
-  // the  x = target[0]  plane
-  // First find distance of scene point from scene y-axis
-  var sceneR = Math.sqrt( scenePos[0] ** 2 + scenePos[2] ** 2 );
-  // If too short, exit rather than tipping poles out of y-z plane
-  if ( sceneR < Math.abs(target[0]) ) return;
-  var targetRotY = Math.asin( target[0] / sceneR );
-  outRotation[0] =
-    Math.atan2( scenePos[0], scenePos[2] ) - // Y-angle of scene vector
-    // Math.asin( target[0] / sceneR );       // Y-angle of target point
-    targetRotY;
-
-  // We now know the x and y coordinates of the scene vector after rotation
-  // around the y-axis: (x = target[0], y = scenePos[1])
-  // Find the z-coordinate so we can compute the remaining required rotation
-  var zRotated = sceneR * Math.cos(targetRotY);
-
-  // Find the rotation about the screen x-axis required to bring the scene
-  // point into the target y = target[1] plane
-  // Assumes 0 angle is aligned along Z, and angle > 0 is rotation toward -y !
-  outRotation[1] =
-    Math.atan2( -1 * target[1], target[2] ) -  // X-angle of target point
-    Math.atan2( -1 * scenePos[1], zRotated );  // X-angle of scene vector
-
-  return;
-}
-
-// initRotation: Updates rotations and rotation velocities based on forces
-// applied via a mouse click & drag event.
-function initRotation( ellipsoid ) {
-  const w0 = 40.0;
-  const extension = new Float64Array(3);
-
-  return function(position, velocity, mouse3d, deltaTime) {
-    // Input mouse3d is a pointer to a mouse object
-    // Inputs position, velocity are pointers to vec3s
-    // Input deltaTime is a primitive floating point value
-
-    // Find the displacement of the clicked position on the globe
-    // from the current mouse position
-    subtract(extension, mouse3d.position, mouse3d.clickPosition);
-
-    // Convert to changes in longitude, latitude, and altitude
-    ellipsoid.ecefToDeltaLonLatAlt(extension, extension,
-      mouse3d.clickPosition, position);
-    // Ignore altitude change for now
-    extension[2] = 0.0;
-
-    updateOscillator(position, velocity, extension, w0, deltaTime, 0, 1);
-    return;
-  };
-}
-
-// initCoast: Update rotations based on a freely spinning globe (no forces)
-function initCoast( ellipsoid ) {
-  const damping = 3.0;
-  const radius = ellipsoid.meanRadius();
-  const minSpeed = 0.03;
-
-  var dvDamp = 0.0;
-
-  return function( position, velocity, deltaTime ) {
-    // Inputs rotation, rotationVel are pointers to 3-element arrays
-    // Input deltaTime is a primitive value (floating point)
-    // TODO: switch to exact formula? (not finite difference)
-
-    if ( length(velocity) < minSpeed * position[2] / radius ) {
-      // Rotation has almost stopped. Go ahead and stop all the way.
-      set(velocity, 0.0, 0.0, 0.0);
-      return false; // No change to position, no need to re-render
-    }
-
-    // Adjust previous velocities for damping over the past time interval
-    dvDamp = -1.0 * damping * deltaTime;
-    // vec3.scaleAndAdd(velocity, velocity, velocity, dvDamp);
-    velocity[0] += velocity[0] * dvDamp;
-    velocity[1] += velocity[1] * dvDamp;
-
-    // Update rotations
-    // vec3.scaleAndAdd(position, position, velocity, deltaTime);
-    position[0] += velocity[0] * deltaTime;
-    position[1] += velocity[1] * deltaTime;
-    return true;    // Position changed, need to re-render
-  };
-}
-
-function initProjector(ellipsoid, camPosition, camInverse, screen) {
-  const rayVec = new Float64Array(3);
-  const ecefTmp = new Float64Array(3);
-
-  return {
-    ecefToScreenRay,
-    lonLatToScreenXY,
-  };
-
-  function lonLatToScreenXY(xy, lonLat) {
-    ellipsoid.geodetic2ecef(ecefTmp, lonLat);
-    const visible = ecefToScreenRay(rayVec, ecefTmp); // Overwrites rayVec!
-
-    xy[0] = screen.width() * ( 1 + rayVec[0] / screen.rightEdge() ) / 2;
-    xy[1] = screen.height() * ( 1 - rayVec[1] / screen.topEdge() ) / 2;
-    return visible;
-  }
-
-  function ecefToScreenRay(screenRay, ecefPosition) {
-    // For a given point on the ellipsoid (in ECEF coordinates) find the
-    // rayVec from a given camera position that will intersect it
-
-    // Translate to camera position
-    subtract(rayVec, ecefPosition, camPosition);
-    // rayVec now points from camera to ecef. The sign of the
-    // dot product tells us whether it is beyond the horizon
-    const visible = ( dot(rayVec, ecefPosition) < 0 );
-
-    // Rotate to camera orientation
-    transformMat4$1(screenRay, rayVec, camInverse);
-
-    // Normalize to z = -1
-    screenRay[0] /= -screenRay[2];
-    screenRay[1] /= -screenRay[2];
-    screenRay[2] = -1.0;
-
-    return visible;
-  }
-}
-
-function initCameraDynamics(screen, ellipsoid, initialPosition) {
-  // Position & velocity are computed in latitude & longitude in radians, and
-  //   altitude defined by distance along surface normal, in the same length
-  //   units as semiMajor and semiMinor in ellipsoid.js
-  const position = new Float64Array(initialPosition);
-  const velocity = new Float64Array(3); // Initializes to [0,0,0]
-
-  // Initialize ECEF position, rotation matrix, inverse, and update method
-  const ecef = initECEF(ellipsoid, position);
-
-  // Keep track of the longitude/latitude of the edges of the screen
-  const edges = initEdgePoints(ellipsoid, ecef.position, ecef.rotation, screen);
-  // Initialize transforms from ellipsoid to screen positions
-  const projector = initProjector(ellipsoid,
-    ecef.position, ecef.inverse, screen);
-
-  // Initialize some values and working arrays
-  var time = 0.0;
-  const rayVec = new Float64Array(4);
-
-  // Initialize values & update functions for translations & rotations
-  const zoom   = initZoom(ellipsoid);
-  const rotate = initRotation(ellipsoid);
-  const coast  = initCoast(ellipsoid);
-
-  // Return methods to read/update state
-  return {
-    position, // WARNING: Exposes local array to changes from outside
-    edgesPos: edges.lonLats,
-
-    ecefPos: ecef.position,
-    rotation: ecef.rotation,
-    inverse: ecef.inverse,
-
-    lonLatToScreenXY: projector.lonLatToScreenXY,
-
-    update,
-    stopCoast,
-    stopZoom,
-  };
-
-  function stopCoast() {
-    velocity[0] = 0.0;
-    velocity[1] = 0.0;
-  }
-  function stopZoom() {
-    velocity[2] = 0.0;
-  }
-
-  function update(newTime, resized, cursor3d) {
-    // Input time is a primitive floating point value
-    // Input cursor3d is a pointer to an object
-    const deltaTime = newTime - time;
-    time = newTime;
-    // If timestep too big, wait till next frame to update physics
-    if (deltaTime > 0.25) return resized;
-
-    var needToRender;
-    if ( cursor3d.isClicked() ) {       // Rotate globe based on cursor drag
-      rotate( position, velocity, cursor3d, deltaTime );
-      needToRender = true;
-    } else {                           // Let globe spin freely
-      needToRender = coast( position, velocity, deltaTime );
-    }
-    if ( cursor3d.isZooming() ) {       // Update zoom
-      // Update ECEF position and rotation/inverse matrices
-      ecef.update(position);
-      // Update 2D screen position of 3D zoom position
-      var visible = projector.ecefToScreenRay( rayVec, cursor3d.zoomPosition );
-      if (visible) {
-        if ( cursor3d.isClicked() ) cursor3d.zoomRay.set(rayVec);
-        zoom( position, velocity, cursor3d, deltaTime, cursor3d.zoomFixed() );
-      } else {
-        stopZoom(); // TODO: is this needed? Might want to keep coasting
-        cursor3d.stopZoom();
-      }
-      needToRender = true;
-    }
-
-    needToRender = needToRender || resized;
-    if (needToRender) {
-      ecef.update(position);
-      edges.update();
-    }
-    return needToRender;
-  }
-}
-
-function initCursor3d(getRayParams, ellipsoid, initialPosition) {
-  // Input getRayParams is a method from yawgl.initView, converting screen X/Y
-  //  to a ray shooting into 3D space
-  // Input initialPosition is a geodetic lon/lat/alt vector
+  const cursor2d = initCursor2d(params, camera);
 
   // Cursor positions are computed & stored in ECEF coordinates (x,y,z)
   const cursorPosition = new Float64Array(3);
   const clickPosition = new Float64Array(3);
   const zoomPosition = new Float64Array(3);
-  // Derived geocentric longitude, latitude, altitude
-  const cursorLonLat = new Float64Array(3);
-  // Screen ray for the 2D cursor position
-  const cursorRay = new Float64Array([0.0, 0.0, -1.0, 0.0]);
+  // Track target screen ray and altitude for zooming
+  const zoomRay = new Float64Array([0.0, 0.0, -1.0, 0.0]);
+  let targetHeight = initialPosition[2];
 
   // Flags about the cursor state
-  var onScene = false;
-  var clicked = false;
-  var zooming = false;
-  var wasTapped = false;
-  // Whether to fix the screen position of the zoom
-  var zoomFix = false;
+  let onScene = false;
+  let clicked = false;
+  let zooming = false;
+  let wasTapped = false;
+  let zoomFix = false; // Whether to fix the screen position of the zoom
 
-  // Track target altitude for zooming
-  var targetHeight = initialPosition[2];
-  const minHeight = ellipsoid.meanRadius() * 0.00001;
-  const maxHeight = ellipsoid.meanRadius() * 8.0;
-  // Target screen ray for zooming
-  const zoomRay = new Float64Array([0.0, 0.0, -1.0, 0.0]);
-
-  // Local working vector
-  const ecefRay = new Float64Array(4);
-
-  // Return methods to read/update cursorPosition
   return {
     // POINTERs to local arrays. WARNING: local vals can be changed outside!
-    position: cursorPosition, // TODO: why make the name more ambiguous?
-    cursorLonLat,
+    cursorLonLat: cursor2d.cursorLonLat,
+    cursorPosition,
     clickPosition,
     zoomPosition,
     zoomRay,
 
-    // Methods to report local state.
-    // These protect the local value, since primitives are passed by value
+    // Methods to report local state
+    hasChanged: () => cursor2d.hasChanged() || wasTapped,
     isOnScene: () => onScene,
     isClicked: () => clicked,
     wasTapped: () => wasTapped,
@@ -10215,128 +9897,283 @@ function initCursor3d(getRayParams, ellipsoid, initialPosition) {
     stopZoom,
   };
 
-  function update(cursor2d, camera) {
-    // Get screen ray in model coordinates (ECEF)
-    getRayParams(cursorRay, cursor2d.x(), cursor2d.y());
-    transformMat4(ecefRay, cursorRay, camera.rotation);
-
-    // Find intersection of ray with ellipsoid
-    onScene = ellipsoid.shoot(cursorPosition, camera.ecefPos, ecefRay);
+  function update(position, dynamics) {
+    onScene = cursor2d.project(cursorPosition);
     if (!onScene) {
-      clicked = false;
-      stopZoom(camera.position[2]);
-      cursor2d.reset();
-      return;
+      clicked = zoomFix = false;
+      return cursor2d.reset();
     }
 
-    // Update cursor longitude/latitude
-    ellipsoid.ecef2geocentric(cursorLonLat, cursorPosition);
-
-    if ( cursor2d.touchEnded() ) {
-      clicked = false;
-      zoomFix = false;
-    }
+    if (cursor2d.touchEnded()) clicked = zoomFix = false;
     wasTapped = cursor2d.tapped();
 
-    if ( cursor2d.touchStarted() ) {
-      // Set click position
+    if (cursor2d.touchStarted()) {
       clicked = true;
       clickPosition.set(cursorPosition);
       // Assuming this is a click or single touch, stop zooming
-      stopZoom(camera.position[2]);
-      // Also stop any coasting in the altitude direction
-      camera.stopZoom();
+      stopZoom(position[2]);
+      dynamics.stopZoom(); // Stops coasting in altitude direction
       // If this was actually a two-touch zoom, then cursor2d.zoomStarted()...
     }
 
-    if ( cursor2d.zoomStarted() ) {
-      zooming = true;
-      zoomFix = true;
+    if (cursor2d.zoomStarted()) {
+      zooming = zoomFix = true;
       zoomPosition.set(cursorPosition);
-      zoomRay.set(cursorRay);
-      if (!clicked) camera.stopCoast();
+      zoomRay.set(cursor2d.screenRay);
+      if (!clicked) dynamics.stopCoast();
     }
 
-    if ( cursor2d.zoomed() ) {
+    if (cursor2d.zoomed()) {
       zooming = true;
       targetHeight *= cursor2d.zscale();
       targetHeight = Math.min(Math.max(minHeight, targetHeight), maxHeight);
     }
 
     cursor2d.reset();
-    return;
   }
 
   function stopZoom(height) {
-    zooming = false;
-    zoomFix = false;
+    zooming = zoomFix = false;
     if (height !== undefined) targetHeight = height;
   }
 }
 
-const degrees = 180.0 / Math.PI;
+function oscillatorChange(x, v, t, w0) {
+  // For a critically damped oscillator with natural frequency w0, find
+  // the change in position x and velocity v over timestep t.  See
+  // https://mathworld.wolfram.com/CriticallyDampedSimpleHarmonicMotion.html
+  const expTerm = Math.exp(-w0 * t);
+  const Bt = (v + w0 * x) * t;
+  const dx = (x + Bt) * expTerm - x;
+  const dv = (v - w0 * Bt) * expTerm - v;
+  return [dx, dv];
+}
 
-function init$1(display, center, altitude) {
-  // Input display is an HTML element where the ball will be represented
-  // Input center is a pointer to a 2-element array containing initial
-  // longitude and latitude for the camera
-  // Input altitude is a floating point value indicating initial altitude
+function getCamPos(centerDist, zoomPos, zoomRay, ellipsoid) {
+  // See https://en.wikipedia.org/wiki/Dragonfly#Motion_camouflage
+  // Returns the [lon, lat] where a camera at centerDist km from the
+  // ellipsoid center will have zoomPos aligned along zoomRay
+  const { abs, hypot, asin, cos, atan2 } = Math;
 
-  // Add event handlers and position tracking to display element
-  const cursor2d = initTouch(display);
-  // Add a view object to compute ray parameters at points on the display
-  const view = initView(display, 25.0);
+  // Find the ray-sphere intersection in unrotated model space coordinates
+  const unrotatedCamPos = [0.0, 0.0, centerDist];
+  const target = new Float64Array(3);
+  const intersected = ellipsoid.shoot(target, unrotatedCamPos, zoomRay);
+  if (!intersected) return;
 
-  // Initialize ellipsoid, and methods for computing positions relative to it
-  const ellipsoid = initEllipsoid();
+  // Find the rotation about the y-axis required to bring zoomPos into the
+  // x = target[0] plane
+  const [zoomX, zoomY, zoomZ] = zoomPos;
+  const zoomR = hypot(zoomX, zoomZ);
+  if (zoomR < abs(target[0])) return;
+  const targetRotY = asin(target[0] / zoomR); // ?= atan2(target[0], target[2])
+  const rotY = atan2(zoomX, zoomZ) - targetRotY;
 
-  // Initialize camera dynamics: time, position, velocity, etc.
-  // First check and convert user parameters for initial position
-  var initialPos = (center && Array.isArray(center) && center.length === 2)
-    ? [center[0] / degrees, center[1] / degrees]
-    : [0.0, 0.0];
-  initialPos[2] = (altitude)
-    ? altitude
-    : 4.0 * ellipsoid.meanRadius();
-  const camera = initCameraDynamics(view, ellipsoid, initialPos);
+  // After rotation around Y, zoomPos will be aligned with x = target[0].
+  // Now find the rotation around X to align with y = target[1]
+  const targetRotX = atan2(target[2], target[1]);
+  const zRotated = zoomR * cos(targetRotY);
+  const rotX = atan2(zRotated, zoomY) - targetRotX;
 
-  // Initialize interaction with the ellipsoid via the mouse and screen
-  const cursor3d = initCursor3d(view.getRayParams, ellipsoid, camera.position);
+  // Note signs: rotX ~ -latitude
+  return [rotY, -rotX];
+}
 
-  var camMoving, cursorChanged;
+function limitRotation(dPos) {
+  const { abs, min, max, PI } = Math;
+  const maxRotation = 0.15;
+
+  // Check for longitude value crossing antimeridian
+  if (dPos[0] >  PI) dPos[0] -= 2.0 * PI;
+  if (dPos[0] < -PI) dPos[0] += 2.0 * PI;
+
+  if (abs(dPos[0]) < maxRotation) return false;
+
+  const tmp = min(max(-maxRotation, dPos[0]), maxRotation) / dPos[0];
+  dPos[0] *= tmp;
+  dPos[1] *= tmp;
+  return true;
+}
+
+function initZoom(ellipsoid, cursor3d) {
+  // Update camera altitude based on target set by mouse wheel events
+  //  or two-finger pinch movements
+  const { zoomTarget, zoomPosition, zoomRay, stopZoom } = cursor3d;
+
+  const w0 = 14.14; // Natural frequency of oscillator
+  const minVelocity = 0.001;
+  const minEnergy = 0.5 * minVelocity ** 2; // ASSUME mass == 1
+
+  return function(position, velocity, dt) {
+    const stretch = position[2] - zoomTarget();
+    const [dz, dVz] = oscillatorChange(stretch, velocity[2], dt, w0);
+    velocity[2] += dVz;
+
+    // Scale rotational velocity by the ratio of the height change
+    const heightScale = 1.0 + dz / position[2];
+    velocity[0] *= heightScale;
+    velocity[1] *= heightScale;
+
+    const dPos = new Float64Array([0.0, 0.0, dz]);
+    const centerDist = position[2] + dz + ellipsoid.meanRadius();
+    const newRotation = (cursor3d.zoomFixed())
+      ? getCamPos(centerDist, zoomPosition, zoomRay, ellipsoid)
+      : null;
+    if (newRotation) {
+      dPos[0] = newRotation[0] - position[0];
+      dPos[1] = newRotation[1] - position[1];
+    }
+    const limited = limitRotation(dPos);
+
+    const rotating = cursor3d.isClicked() || limited;
+    const energy = 0.5 * velocity[2] ** 2 + // Kinetic
+      0.5 * (w0 * (stretch + dz)) ** 2;     // Potential
+    // Stop if we are already near steady state
+    if (!rotating && energy < minEnergy * zoomTarget()) {
+      velocity[2] = 0.0;
+      stopZoom();
+    }
+
+    return dPos;
+  };
+}
+
+function initRotation(ellipsoid, cursor3d) {
+  // Update rotations and rotation velocities based on forces applied
+  // via a mouse click & drag event
+  const w0 = 40.0;
+  const extension = new Float64Array(3);
+  const { cursorPosition, clickPosition } = cursor3d;
+
+  return function(position, velocity, dt) {
+    // Find the displacement of the clicked position on the globe
+    // from the current mouse position
+    subtract(extension, cursorPosition, clickPosition);
+
+    // Convert to changes in longitude, latitude, and altitude
+    ellipsoid.ecefToDeltaLonLatAlt(extension, extension,
+      clickPosition, position);
+
+    const [x, y] = extension;
+    const [dLon, dVx] = oscillatorChange(x, velocity[0], dt, w0);
+    const [dLat, dVy] = oscillatorChange(y, velocity[1], dt, w0);
+
+    velocity[0] += dVx;
+    velocity[1] += dVy;
+
+    return new Float64Array([dLon, dLat, 0.0]);
+  };
+}
+
+function initCoast(ellipsoid) {
+  // Update rotations based on a freely spinning globe (no forces)
+  const damping = 3.0; // Viscous damping
+  const radius = ellipsoid.meanRadius();
+  const minSpeed = 0.03;
+
+  return function(position, velocity, dt) {
+    // TODO: switch to exact formula? (not finite difference)
+
+    const speed = Math.hypot(velocity[0], velocity[1]);
+    if (speed < minSpeed * position[2] / radius) {
+      velocity.fill(0.0, 0, 2);
+      return new Float64Array(3); // No change in position
+    }
+
+    // Adjust previous velocities for damping over the past time interval
+    const dvDamp = -1.0 * damping * dt;
+    velocity[0] += velocity[0] * dvDamp;
+    velocity[1] += velocity[1] * dvDamp;
+
+    // Return change in position
+    const dLon = velocity[0] * dt;
+    const dLat = velocity[1] * dt;
+    return new Float64Array([dLon, dLat, 0.0]);
+  };
+}
+
+function initCameraDynamics(ellipsoid, camera, cursor3d) {
+  // Velocity is the time differential of camera.position
+  const velocity = new Float64Array(3);
+
+  // Initialize some values and working arrays
+  let time = 0.0;
+  const rayVec = new Float64Array(4);
+
+  // Initialize values & update functions for translations & rotations
+  const zoom   = initZoom(ellipsoid, cursor3d);
+  const rotate = initRotation(ellipsoid, cursor3d);
+  const coast  = initCoast(ellipsoid);
+
+  // Return methods to read/update state
+  return {
+    update,
+    stopZoom: () => velocity.fill(0.0, 2),
+    stopCoast: () => velocity.fill(0.0, 0, 2),
+  };
+
+  function update(newTime) {
+    const deltaTime = newTime - time;
+    time = newTime;
+    // If timestep too big, wait till next frame to update physics
+    if (deltaTime > 0.25) return false;
+
+    const rotation = (cursor3d.isClicked())
+      ? rotate(camera.position(), velocity, deltaTime)
+      : coast(camera.position(), velocity, deltaTime);
+    camera.update(rotation);
+
+    const rotated = rotation.some(c => c != 0.0);
+    if (!cursor3d.isZooming()) return rotated;
+
+    // Update 2D screen position of 3D zoom position
+    const visible = camera.ecefToScreenRay(rayVec, cursor3d.zoomPosition);
+    if (!visible) {
+      velocity.fill(0.0, 2); // TODO: is this needed? Or keep coasting?
+      cursor3d.stopZoom();
+      return rotated;
+    }
+
+    if (cursor3d.isClicked()) cursor3d.zoomRay.set(rayVec);
+    const zoomChange = zoom(camera.position(), velocity, deltaTime);
+    camera.update(zoomChange);
+    return true;
+  }
+}
+
+function init$1(userParams) {
+  const params = setParams$1(userParams);
+  const { ellipsoid, view, units } = params;
+
+  const camera = initCamera(params);
+  const cursor = initCursor3d(params, camera);
+  const dynamics = initCameraDynamics(ellipsoid, camera, cursor);
+
+  let camMoving, cursorChanged;
 
   return {
     view,
-
     radius: ellipsoid.meanRadius,
 
+    project: (xy, geodetic) => camera.project(xy, units.convert(geodetic)),
+    cameraPos: () => units.invert(camera.position()),
+    cursorPos: () => units.invert(cursor.cursorLonLat),
+
     camMoving: () => camMoving,
-    cameraPos: camera.position,
-    edgesPos: camera.edgesPos,
-
-    lonLatToScreenXY: camera.lonLatToScreenXY,
-
-    cursorPos: cursor3d.cursorLonLat,
-    isOnScene: cursor3d.isOnScene,
+    isOnScene: cursor.isOnScene,
+    wasTapped: cursor.wasTapped,
     cursorChanged: () => cursorChanged,
-    wasTapped: cursor3d.wasTapped,
 
     update,
   };
 
   function update(time) {
-    // Input time is a primitive floating point value representing the
-    // time this function was called, in seconds
-
-    // Check for changes in display size
+    // Input represents the time this function was called, in seconds
     const resized = view.changed();
 
-    // Update camera dynamics
-    camMoving = camera.update(time, resized, cursor3d);
-
-    // Update cursor positions, if necessary
-    cursorChanged = cursor2d.hasChanged() || camMoving || cursor3d.wasTapped();
-    if (cursorChanged) cursor3d.update(cursor2d, camera);
+    camMoving = dynamics.update(time) || resized;
+    cursorChanged = cursor.hasChanged() || camMoving;
+    if (cursorChanged) cursor.update(camera.position(), dynamics);
 
     return camMoving;
   }
@@ -10644,11 +10481,12 @@ function printToolTip(toolTip, ball) {
   if (!toolTip) return;
 
   // Print altitude and lon/lat of camera
-  const alt = ball.cameraPos[2].toPrecision(5);
-  toolTip.innerHTML = alt + "km " + lonLatString(...ball.cameraPos);
+  const cameraPos = ball.cameraPos();
+  const alt = cameraPos[2].toPrecision(5);
+  toolTip.innerHTML = alt + "km " + lonLatString(...cameraPos);
 
   if (ball.isOnScene()) {
-    toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos);
+    toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos());
   }
 }
 
@@ -10732,7 +10570,7 @@ function initMarkers(globe, container) {
   }
 
   function setPosition(marker) {
-    const visible = globe.lonLatToScreenXY(marker.screenPos, marker.lonLat);
+    const visible = globe.project(marker.screenPos, marker.lonLat);
 
     Object.assign(marker.element.style, {
       display: (visible) ? "inline-block" : "none",
@@ -10753,7 +10591,11 @@ function setup(map, params) {
   const { globeDiv, toolTip, center, altitude, context } = params;
   var requestID;
 
-  const ball = init$1(globeDiv, center, altitude);
+  const ball = init$1({
+    display: globeDiv, 
+    position: [center[0], center[1], altitude],
+    units: "radians",
+  });
   const satView = init({
     context: context,
     globeRadius: ball.radius(),
@@ -10764,7 +10606,7 @@ function setup(map, params) {
 
   return {
     mapLoaded: map.loaded,
-    select: (layer, dxy) => map.select(layer, ball.cursorPos, dxy),
+    select: (layer, dxy) => map.select(layer, ball.cursorPos(), dxy),
     showLayer: map.showLayer,
     hideLayer: map.hideLayer,
     getZoom: map.getZoom,
@@ -10794,8 +10636,8 @@ function setup(map, params) {
     var moving = ball.update(time * 0.001); // Convert time from ms to seconds
 
     if (moving || map.loaded() < 1.0) {
-      map.draw(ball.cameraPos, ball.radius(), ball.view);
-      satView.draw(ball.cameraPos, ball.view.maxRay);
+      map.draw(ball.cameraPos(), ball.radius(), ball.view);
+      satView.draw(ball.cameraPos(), ball.view.maxRay);
     }
 
     if (moving) markers.update();

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -561,10 +561,11 @@ function setParams$3(userParams) {
   }
 }
 
+const { cos, tan, atan, exp, log, PI, min, max } = Math;
 // Maximum latitude for Web Mercator: 85.0113 degrees. Beware rounding!
-const maxMercLat$1 = 2.0 * Math.atan( Math.exp(Math.PI) ) - Math.PI / 2.0;
-const clipLat = (lat) => Math.min(Math.max(-maxMercLat$1, lat), maxMercLat$1);
-const degrees = 180.0 / Math.PI;
+const maxMercLat = 2.0 * atan(exp(PI)) - PI / 2.0;
+const clipLat = (lat) => min(max(-maxMercLat, lat), maxMercLat);
+const degrees = 180.0 / PI;
 
 function getProjection(units) {
   switch (units) {
@@ -594,22 +595,18 @@ function getProjection(units) {
 function forward([lon, lat]) {
   // Convert input longitude in radians to a Web Mercator x-coordinate
   // where x = 0 at lon = -PI, x = 1 at lon = +PI
-  const x = 0.5 + 0.5 * lon / Math.PI;
+  const x = 0.5 + 0.5 * lon / PI;
 
   // Convert input latitude in radians to a Web Mercator y-coordinate
   // where y = 0 at lat = maxMercLat, y = 1 at lat = -maxMercLat
-  let y = 0.5 - 0.5 / Math.PI *
-    Math.log( Math.tan(Math.PI / 4.0 + clipLat(lat) / 2.0) );
+  const y = 0.5 - 0.5 / PI *
+    log(tan(PI / 4.0 + clipLat(lat) / 2.0));
 
   // Clip y to the range [0, 1] (it does not wrap around)
-  y = Math.min(Math.max(0.0, y), 1.0);
-
-  return [x, y];
+  return [x, min(max(0.0, y), 1.0)];
 }
 
 function inverse([x, y]) {
-  const { atan, exp, PI } = Math;
-
   const lon = 2.0 * (x - 0.5) * PI;
   const lat = 2.0 * atan(exp(PI * (1.0 - 2.0 * y))) - PI / 2;
 
@@ -617,17 +614,18 @@ function inverse([x, y]) {
 }
 
 function scale$1(point) {
-  const lat = point[1];
+  const lat = clipLat(point[1]);
   // Return value scales a (differential) distance along the plane tangent to
   // the sphere at [lon, lat] to a distance in map coordinates.
   // NOTE: ASSUMES a sphere of radius 1! Input distances should be
   //  pre-normalized by the appropriate radius
-  return 1 / (2 * Math.PI * Math.cos( clipLat(lat) ));
+  return 1 / (2 * PI * cos(lat));
 }
 
-function initCoords({ size, center, zoom, clampY, projection }) {
+function initCoords({ getViewport, center, zoom, clampY, projection }) {
+  const { log2, min, max, round, floor } = Math;
   const minTileSize = 256;
-  const logTileSize = Math.log2(minTileSize);
+  const logTileSize = log2(minTileSize);
 
   const transform = {
     k: 1, // Size of the world map, in pixels
@@ -641,8 +639,8 @@ function initCoords({ size, center, zoom, clampY, projection }) {
 
   return {
     getViewport,
-    getTransform,
-    getZoom,
+    getTransform: () => Object.assign({}, transform),
+    getZoom: () => max(0, log2(transform.k) - 9),
     getCamPos: () => camPos.slice(),
     getScale: () => scale.slice(),
 
@@ -652,53 +650,37 @@ function initCoords({ size, center, zoom, clampY, projection }) {
     localToGlobal,
   };
 
-  function getViewport(pixRatio = 1) {
-    return [size.width / pixRatio, size.height / pixRatio];
-  }
-
-  function getTransform(pixRatio = 1) {
-    return Object.entries(transform)
-      .reduce((d, [k, v]) => (d[k] = v / pixRatio, d), {});
-  }
-
-  function getZoom(pixRatio = 1) {
-    return Math.max(0, Math.log2(transform.k / pixRatio) - 9);
-  }
-
-  function setTransform(rawTransform, pixRatio = 1) {
+  function setTransform({ k, x, y }) {
     // Input transforms map coordinates [x, y] into viewport coordinates
-    // Units are in pixels
-    const kRaw = rawTransform.k * pixRatio;
-    const xRaw = rawTransform.x * pixRatio;
-    const yRaw = rawTransform.y * pixRatio;
+    const [width, height] = getViewport();
 
-    // Round kRaw to ensure tile pixels align with screen pixels
-    const z = Math.log2(kRaw) - logTileSize;
-    const z0 = Math.floor(z);
-    const tileScale = Math.round(2 ** (z - z0) * minTileSize);
+    // Round k to ensure tile pixels align with screen pixels
+    const z = log2(k) - logTileSize;
+    const z0 = floor(z);
+    const tileScale = round(2 ** (z - z0) * minTileSize);
     const kNew = clampY
-      ? Math.max(2 ** z0 * tileScale, size.height)
+      ? max(2 ** z0 * tileScale, height)
       : 2 ** z0 * tileScale;
 
     // Adjust translation for the change in scale, and snap to pixel grid
-    const kScale = kNew / kRaw;
+    const kScale = kNew / k;
     // Keep the same map pixel at the center of the viewport
-    const sx = kScale * xRaw + (1 - kScale) * size.width / 2;
-    const sy = kScale * yRaw + (1 - kScale) * size.height / 2;
+    const sx = kScale * x + (1 - kScale) * width / 2;
+    const sy = kScale * y + (1 - kScale) * height / 2;
     // Limit Y so the map doesn't cross a pole
     const yLim = clampY
-      ? Math.min(Math.max(-kNew / 2 + size.height, sy), kNew / 2)
+      ? min(max(-kNew / 2 + height, sy), kNew / 2)
       : sy;
-    const [xNew, yNew] = [sx, yLim].map(Math.round);
+    const [xNew, yNew] = [sx, yLim].map(round);
 
     // Make sure camera is still pointing at the original location: shift from
     // the center [0.5, 0.5] by the change in the translation due to rounding
-    camPos[0] = 0.5 + (xNew - sx) / size.width;
-    camPos[1] = 0.5 + (yNew - sy) / size.height;
+    camPos[0] = 0.5 + (xNew - sx) / width;
+    camPos[1] = 0.5 + (yNew - sy) / height;
 
     // Store the scale of the current map relative to the entire world
-    scale[0] = kNew / size.width;
-    scale[1] = kNew / size.height;
+    scale[0] = kNew / width;
+    scale[1] = kNew / height;
 
     // Return a flag indicating whether the transform changed
     const { k: kOld, x: xOld, y: yOld } = transform;
@@ -707,22 +689,26 @@ function initCoords({ size, center, zoom, clampY, projection }) {
     return true;
   }
 
-  function setCenterZoom(c, z) {
-    const k = 512 * 2 ** z;
+  function setCenterZoom(center, zoom) {
+    const [width, height] = getViewport();
 
-    const [xr, yr] = projection.forward(c);
-    const x = (0.5 - xr) * k + size.width / 2;
-    const y = (0.5 - yr) * k + size.height / 2;
+    const k = 512 * 2 ** zoom;
+    const [xr, yr] = projection.forward(center);
+    const x = (0.5 - xr) * k + width / 2;
+    const y = (0.5 - yr) * k + height / 2;
 
     return setTransform({ k, x, y });
   }
 
-  function localToGlobal([x, y]) {
+  function localToGlobal([xl, yl]) {
     // Convert local map pixels to global XY
     const { x: tx, y: ty, k } = transform;
     // tx, ty is the shift of the map center (in pixels)
     //   relative to the viewport origin (top left corner)
-    return [(x - tx) / k + 0.5, (y - ty) / k + 0.5];
+    const xg = (xl - tx) / k + 0.5;
+    const yg = (yl - ty) / k + 0.5;
+    // Global XY are in the range [0.0, 1.0]. Wrap values outside
+    return [xg - floor(xg), yg - floor(yg)];
   }
 }
 
@@ -731,8 +717,8 @@ function initBackground(context) {
     const { paint } = style;
 
     return function({ zoom }) {
-      let opacity = paint["background-opacity"](zoom);
-      let color = paint["background-color"](zoom);
+      const opacity = paint["background-opacity"](zoom);
+      const color = paint["background-color"](zoom);
       context.clear(color.map(c => c * opacity));
     };
   }
@@ -838,13 +824,13 @@ function initGrid(framebufferSize, useProgram, setters) {
     [0, 1, 2].forEach(addSubset);
 
     function addSubset(repeat) {
-      let shift = repeat * numTiles;
-      let tiles = tileset.filter(tile => {
-        let delta = tile.x - x;
+      const shift = repeat * numTiles;
+      const tiles = tileset.filter(tile => {
+        const delta = tile.x - x;
         return (delta >= shift && delta < shift + numTiles);
       });
       if (!tiles.length) return;
-      let setter = () => mapShift([dx + shift * pixScale, dy, pixScale]);
+      const setter = () => mapShift([dx + shift * pixScale, dy, pixScale]);
       subsets.push({ tiles, setter });
     }
 
@@ -871,7 +857,7 @@ function initSetters(pairs, uniformSetters) {
   return pairs
     .filter(([get]) => get.type !== "property")
     .map(([get, key]) => {
-      let set = uniformSetters[key];
+      const set = uniformSetters[key];
       return (z, f) => set(get(z, f));
     });
 }
@@ -916,7 +902,7 @@ function initCircle(context, framebufferSize, preamble) {
 
   function load(buffers) {
     const attributes = Object.entries(attrInfo).reduce((d, [key, info]) => {
-      let data = buffers[key];
+      const data = buffers[key];
       if (data) d[key] = initAttribute(Object.assign({ data }, info));
       return d;
     }, { quadPos });
@@ -1086,7 +1072,7 @@ function initLineLoader(context, constructVao) {
     }
 
     const attributes = Object.entries(attrInfo).reduce((d, [key, info]) => {
-      let data = buffers[key];
+      const data = buffers[key];
       if (data) d[key] = initAttribute(Object.assign({ data }, info));
       return d;
     }, geometryAttributes);
@@ -1167,7 +1153,7 @@ function initFillLoader(context, constructVao) {
 
   return function(buffers) {
     const attributes = Object.entries(attrInfo).reduce((d, [key, info]) => {
-      let data = buffers[key];
+      const data = buffers[key];
       if (data) d[key] = initAttribute(Object.assign({ data }, info));
       return d;
     }, {});
@@ -1263,7 +1249,7 @@ function initTextLoader(context, constructVao) {
 
   return function(buffers) {
     const attributes = Object.entries(attrInfo).reduce((d, [key, info]) => {
-      let data = buffers[key];
+      const data = buffers[key];
       if (data) d[key] = initAttribute(Object.assign({ data }, info));
       return d;
     }, { quadPos });
@@ -1357,50 +1343,9 @@ function initGLpaint(context, framebuffer) {
   return { prep, loadBuffers, loadAtlas, initPainter };
 }
 
-function initEventHandler() {
-  // Stores events and listeners. Listeners will be executed even if
-  // the event occurred before the listener was added
-
-  const events = {};    // { type1: data1, type2: data2, ... }
-  const listeners = {}; // { type1: { id1: func1, id2: func2, ...}, type2: ... }
-  var globalID = 0;
-
-  function emitEvent(type, data = "1") {
-    events[type] = data;
-
-    const audience = listeners[type];
-    if (!audience) return;
-
-    Object.values(audience).forEach(listener => listener(data));
-  }
-
-  function addListener(type, listener) {
-    if (!listeners[type]) listeners[type] = {};
-
-    const id = ++globalID;
-    listeners[type][id] = listener;
-
-    if (events[type]) listener(events[type]);
-    return id;
-  }
-
-  function removeListener(type, id) {
-    const audience = listeners[type];
-    if (audience) delete audience[id];
-  }
-
-  return {
-    emitEvent,
-    addListener,
-    removeListener,
-  };
-}
-
 function setParams$1$1(userParams) {
   const gl = userParams.context.gl;
-  if (!(gl instanceof WebGLRenderingContext)) {
-    fail$1("no valid WebGL context");
-  }
+  if (!(gl instanceof WebGLRenderingContext)) fail$1("no valid WebGL context");
 
   const {
     context,
@@ -1418,34 +1363,38 @@ function setParams$1$1(userParams) {
     fail$1("no valid framebuffer");
   }
 
-  if (!size || !allPosInts(size.width, size.height)) {
-    fail$1("invalid size object");
-  }
-
-  if (!Array.isArray(center) || center.length < 2) {
-    fail$1("invalid center coordinates");
-  }
-
-  if (!Number.isFinite(zoom)) {
-    fail$1("invalid zoom value");
-  }
+  const sizeType =
+    (size && allPosInts(size.clientWidth, size.clientHeight)) ? "client" :
+    (size && allPosInts(size.width, size.height)) ? "raw" :
+    null;
+  if (!sizeType) fail$1("invalid size object in framebuffer");
+  const getViewport = (sizeType === "client")
+    ? () => ([size.clientWidth, size.clientHeight])
+    : () => ([size.width, size.height]);
 
   const validUnits = ["degrees", "radians", "xy"];
   if (!validUnits.includes(units)) fail$1("invalid units");
   const projection = getProjection(units);
 
   // Convert initial center position from degrees to the specified units
+  if (!checkCoords$1(center, 2)) fail$1("invalid center coordinates");
   const projCenter = getProjection("degrees").forward(center);
   if (!all0to1(...projCenter)) fail$1 ("invalid center coordinates");
   const invCenter = projection.inverse(projCenter);
 
+  if (!Number.isFinite(zoom)) fail$1("invalid zoom value");
+
+  const coords = initCoords({
+    getViewport, projection,
+    center: invCenter,
+    zoom, clampY,
+  });
+
   return {
     gl, framebuffer,
-    projection,
-    coords: initCoords({ size, center: invCenter, zoom, clampY, projection }),
+    projection, coords,
     style, mapboxToken,
     context: initGLpaint(context, framebuffer),
-    eventHandler: initEventHandler(),
   };
 }
 
@@ -1459,6 +1408,13 @@ function allPosInts(...vals) {
 
 function all0to1(...vals) {
   return vals.every(v => Number.isFinite(v) && v >= 0 && v <= 1);
+}
+
+function checkCoords$1(p, n) {
+  const isArray = Array.isArray(p) ||
+    (ArrayBuffer.isView(p) && !(p instanceof DataView));
+  return isArray && p.length >= n &&
+    p.slice(0, n).every(Number.isFinite);
 }
 
 function expandStyleURL(url, token) {
@@ -1939,13 +1895,13 @@ function buildInterpolator(stops, base = 1) {
   const interpolate = getInterpolator(type);
 
   return function(x) {
-    let iz = stops.findIndex(stop => stop[0] > x);
+    const iz = stops.findIndex(stop => stop[0] > x);
 
     if (iz === 0) return stops[0][1]; // x is below first stop
     if (iz < 0) return stops[izm][1]; // x is above last stop
 
-    let [x0, y0] = stops[iz - 1];
-    let [x1, y1] = stops[iz];
+    const [x0, y0] = stops[iz - 1];
+    const [x1, y1] = stops[iz];
 
     return interpolate(y0, scale(x0, x, x1), y1);
   };
@@ -1958,7 +1914,7 @@ function getType(v) {
 function convertIfColor(val) {
   // Convert CSS color strings to clamped RGBA arrays for WebGL
   if (!color(val)) return val;
-  let c = rgb(val);
+  const c = rgb(val);
   return [c.r / 255, c.g / 255, c.b / 255, c.opacity];
 }
 
@@ -2383,23 +2339,23 @@ initZeroTimeouts$1();
 function initZeroTimeouts$1() {
   // setTimeout with true zero delay. https://github.com/GlobeletJS/zero-timeout
   const timeouts = [];
-  var taskId = 0;
+  let taskId = 0;
 
   // Make a unique message, that won't be confused with messages from
   // other scripts or browser tabs
   const messageKey = "zeroTimeout_$" + Math.random().toString(36).slice(2);
 
   // Make it clear where the messages should be coming from
-  const loc = window.location;
-  var targetOrigin = loc.protocol + "//" + loc.hostname;
-  if (loc.port !== "") targetOrigin += ":" + loc.port;
+  const { protocol, hostname, port } = window.location;
+  let targetOrigin = protocol + "//" + hostname;
+  if (port !== "") targetOrigin += ":" + port;
 
   // When a message is received, execute a timeout from the list
   window.addEventListener("message", evnt => {
     if (evnt.source != window || evnt.data !== messageKey) return;
     evnt.stopPropagation();
 
-    let task = timeouts.shift();
+    const task = timeouts.shift();
     if (!task || task.canceled) return;
     task.func(...task.args);
   }, true);
@@ -2413,15 +2369,15 @@ function initZeroTimeouts$1() {
   };
 
   window.clearZeroTimeout = function(id) {
-    let task = timeouts.find(timeout => timeout.id === id);
+    const task = timeouts.find(timeout => timeout.id === id);
     if (task) task.canceled = true;
   };
 }
 
 function init$2() {
   const tasks = [];
-  var taskId = 0;
-  var queueIsRunning = false;
+  let taskId = 0;
+  let queueIsRunning = false;
 
   return {
     enqueueTask,
@@ -2443,7 +2399,7 @@ function init$2() {
   }
 
   function cancelTask(id) {
-    let task = tasks.find(task => task.id === id);
+    const task = tasks.find(task => task.id === id);
     if (task) task.canceled = true;
   }
 
@@ -2464,7 +2420,7 @@ function init$2() {
     if (!queueIsRunning) return;
 
     // Get the next chunk from the current task, and run it
-    let chunk = tasks[0].chunks.shift();
+    const chunk = tasks[0].chunks.shift();
     chunk();
 
     window.setZeroTimeout(runTaskQueue);
@@ -2480,23 +2436,23 @@ initZeroTimeouts();
 function initZeroTimeouts() {
   // setTimeout with true zero delay. https://github.com/GlobeletJS/zero-timeout
   const timeouts = [];
-  var taskId = 0;
+  let taskId = 0;
 
   // Make a unique message, that won't be confused with messages from
   // other scripts or browser tabs
   const messageKey = "zeroTimeout_$" + Math.random().toString(36).slice(2);
 
   // Make it clear where the messages should be coming from
-  const loc = window.location;
-  var targetOrigin = loc.protocol + "//" + loc.hostname;
-  if (loc.port !== "") targetOrigin += ":" + loc.port;
+  const { protocol, hostname, port } = window.location;
+  let targetOrigin = protocol + "//" + hostname;
+  if (port !== "") targetOrigin += ":" + port;
 
   // When a message is received, execute a timeout from the list
   window.addEventListener("message", evnt => {
     if (evnt.source != window || evnt.data !== messageKey) return;
     evnt.stopPropagation();
 
-    let task = timeouts.shift();
+    const task = timeouts.shift();
     if (!task || task.canceled) return;
     task.func(...task.args);
   }, true);
@@ -2510,15 +2466,15 @@ function initZeroTimeouts() {
   };
 
   window.clearZeroTimeout = function(id) {
-    let task = timeouts.find(timeout => timeout.id === id);
+    const task = timeouts.find(timeout => timeout.id === id);
     if (task) task.canceled = true;
   };
 }
 
 function init$1$1() {
   const tasks = [];
-  var taskId = 0;
-  var queueIsRunning = false;
+  let taskId = 0;
+  let queueIsRunning = false;
 
   return {
     enqueueTask,
@@ -2540,7 +2496,7 @@ function init$1$1() {
   }
 
   function cancelTask(id) {
-    let task = tasks.find(task => task.id === id);
+    const task = tasks.find(task => task.id === id);
     if (task) task.canceled = true;
   }
 
@@ -2561,7 +2517,7 @@ function init$1$1() {
     if (!queueIsRunning) return;
 
     // Get the next chunk from the current task, and run it
-    let chunk = tasks[0].chunks.shift();
+    const chunk = tasks[0].chunks.shift();
     chunk();
 
     window.setZeroTimeout(runTaskQueue);
@@ -2619,7 +2575,7 @@ function initWorkers(codeHref, params) {
   const { threads, glyphs, layers, source } = params;
 
   const tasks = {};
-  var msgId = 0;
+  let msgId = 0;
 
   // Initialize the worker threads, and send them the styles
   function trainWorker() {
@@ -3086,13 +3042,13 @@ function buildInterpolator(stops, base = 1) {
   const interpolate = getInterpolator(type);
 
   return function(x) {
-    let iz = stops.findIndex(stop => stop[0] > x);
+    const iz = stops.findIndex(stop => stop[0] > x);
 
     if (iz === 0) return stops[0][1]; // x is below first stop
     if (iz < 0) return stops[izm][1]; // x is above last stop
 
-    let [x0, y0] = stops[iz - 1];
-    let [x1, y1] = stops[iz];
+    const [x0, y0] = stops[iz - 1];
+    const [x1, y1] = stops[iz];
 
     return interpolate(y0, scale(x0, x, x1), y1);
   };
@@ -3105,7 +3061,7 @@ function getType(v) {
 function convertIfColor(val) {
   // Convert CSS color strings to clamped RGBA arrays for WebGL
   if (!color(val)) return val;
-  let c = rgb(val);
+  const c = rgb(val);
   return [c.r / 255, c.g / 255, c.b / 255, c.opacity];
 }
 
@@ -3374,15 +3330,15 @@ function buildFeatureFilter(filterObj) {
   // If this is a combined filter, the vals are themselves filter definitions
   switch (type) {
     case "all": {
-      let filters = vals.map(buildFeatureFilter);  // Iteratively recursive!
+      const filters = vals.map(buildFeatureFilter);  // Iteratively recursive!
       return (d) => filters.every( filt => filt(d) );
     }
     case "any": {
-      let filters = vals.map(buildFeatureFilter);
+      const filters = vals.map(buildFeatureFilter);
       return (d) => filters.some( filt => filt(d) );
     }
     case "none": {
-      let filters = vals.map(buildFeatureFilter);
+      const filters = vals.map(buildFeatureFilter);
       return (d) => filters.every( filt => !filt(d) );
     }
     default:
@@ -3432,7 +3388,7 @@ function initFeatureValGetter(key) {
     case "$type":
       // NOTE: data includes MultiLineString, MultiPolygon, etc-NOT IN SPEC
       return f => {
-        let t = f.geometry.type;
+        const t = f.geometry.type;
         if (t === "MultiPoint") return "Point";
         if (t === "MultiLineString") return "LineString";
         if (t === "MultiPolygon") return "Polygon";
@@ -4312,7 +4268,7 @@ function copyImage(srcImg, dstImg, srcPt, dstPt, size, channels) {
 }
 
 function outOfRange(point, size, image) {
-  let { width, height } = size;
+  const { width, height } = size;
   return (
     width > image.width ||
     height > image.height ||
@@ -4511,7 +4467,7 @@ function buildAtlas(fonts) {
   // Using the updated rects, copy all the bitmaps into one image
   const image = new AlphaImage({ width: w || 1, height: h || 1 });
   Object.entries(fonts).forEach(([font, glyphs]) => {
-    let fontPos = positions[font];
+    const fontPos = positions[font];
     glyphs.forEach(glyph => copyGlyphBitmap(glyph, fontPos, image));
   });
 
@@ -4520,32 +4476,32 @@ function buildAtlas(fonts) {
 
 function getPositions(glyphs) {
   return glyphs.reduce((dict, glyph) => {
-    let pos = getPosition(glyph);
+    const pos = getPosition(glyph);
     if (pos) dict[glyph.id] = pos;
     return dict;
   }, {});
 }
 
 function getPosition(glyph) {
-  let { bitmap: { width, height }, metrics } = glyph;
+  const { bitmap: { width, height }, metrics } = glyph;
   if (width === 0 || height === 0) return;
 
   // Construct a preliminary rect, positioned at the origin for now
-  let w = width + 2 * ATLAS_PADDING$1;
-  let h = height + 2 * ATLAS_PADDING$1;
-  let rect = { x: 0, y: 0, w, h };
+  const w = width + 2 * ATLAS_PADDING$1;
+  const h = height + 2 * ATLAS_PADDING$1;
+  const rect = { x: 0, y: 0, w, h };
 
   return { metrics, rect };
 }
 
 function copyGlyphBitmap(glyph, positions, image) {
-  let { id, bitmap } = glyph;
-  let position = positions[id];
+  const { id, bitmap } = glyph;
+  const position = positions[id];
   if (!position) return;
 
-  let srcPt = { x: 0, y: 0 };
-  let { x, y } = position.rect;
-  let dstPt = { x: x + ATLAS_PADDING$1, y: y + ATLAS_PADDING$1 };
+  const srcPt = { x: 0, y: 0 };
+  const { x, y } = position.rect;
+  const dstPt = { x: x + ATLAS_PADDING$1, y: y + ATLAS_PADDING$1 };
   AlphaImage.copy(bitmap, image, srcPt, dstPt, bitmap);
 }
 
@@ -4569,7 +4525,7 @@ function initGetter(urlTemplate, key) {
     const fontGlyphs = {};
 
     const promises = Object.entries(fontCodes).map(([font, codes]) => {
-      let requests = Array.from(codes, code => getGlyph(font, code));
+      const requests = Array.from(codes, code => getGlyph(font, code));
 
       return Promise.all(requests).then(glyphs => {
         fontGlyphs[font] = glyphs.filter(g => g !== undefined);
@@ -4588,25 +4544,25 @@ function getTokenParser(tokenText) {
 
   // We break tokenText into pieces that are either plain text or tokens,
   // then construct an array of functions to parse each piece
-  var tokenFuncs = [];
-  var charIndex  = 0;
+  const tokenFuncs = [];
+  let charIndex  = 0;
   while (charIndex < tokenText.length) {
     // Find the next token
-    let result = tokenPattern.exec(tokenText);
+    const result = tokenPattern.exec(tokenText);
 
     if (!result) {
       // No tokens left. Parse the plain text after the last token
-      let str = tokenText.substring(charIndex);
+      const str = tokenText.substring(charIndex);
       tokenFuncs.push(() => str);
       break;
     } else if (result.index > charIndex) {
       // There is some plain text before the token
-      let str = tokenText.substring(charIndex, result.index);
+      const str = tokenText.substring(charIndex, result.index);
       tokenFuncs.push(() => str);
     }
 
     // Add a function to process the current token
-    let token = result[1];
+    const token = result[1];
     tokenFuncs.push(props => props[token]);
     charIndex = tokenPattern.lastIndex;
   }
@@ -4617,7 +4573,7 @@ function getTokenParser(tokenText) {
   return function(properties) {
     return tokenFuncs.reduce(concat, "");
     function concat(str, tokenFunc) {
-      let text = tokenFunc(properties) || "";
+      const text = tokenFunc(properties) || "";
       return str += text;
     }
   };
@@ -4702,7 +4658,7 @@ function initCircleParsing(style) {
     };
 
     dataFuncs.forEach(([get, key]) => {
-      let val = get(null, feature);
+      const val = get(null, feature);
       buffers[key] = Array.from({ length }).flatMap(() => val);
     });
 
@@ -4744,7 +4700,7 @@ function initLineParsing(style) {
     };
 
     dataFuncs.forEach(([get, key]) => {
-      let val = get(null, feature);
+      const val = get(null, feature);
       buffers[key] = Array.from({ length }).flatMap(() => val);
     });
 
@@ -4753,7 +4709,7 @@ function initLineParsing(style) {
 }
 
 function flattenLines(geometry) {
-  let { type, coordinates } = geometry;
+  const { type, coordinates } = geometry;
 
   switch (type) {
     case "LineString":
@@ -5070,7 +5026,7 @@ function eliminateHoles(data, holeIndices, outerNode, dim) {
 
     // process holes from left to right
     for (i = 0; i < queue.length; i++) {
-        eliminateHole(queue[i], outerNode);
+        outerNode = eliminateHole(queue[i], outerNode);
         outerNode = filterPoints(outerNode, outerNode.next);
     }
 
@@ -5083,14 +5039,19 @@ function compareX(a, b) {
 
 // find a bridge between vertices that connects hole with an outer ring and and link it
 function eliminateHole(hole, outerNode) {
-    outerNode = findHoleBridge(hole, outerNode);
-    if (outerNode) {
-        var b = splitPolygon(outerNode, hole);
-
-        // filter collinear points around the cuts
-        filterPoints(outerNode, outerNode.next);
-        filterPoints(b, b.next);
+    var bridge = findHoleBridge(hole, outerNode);
+    if (!bridge) {
+        return outerNode;
     }
+
+    var bridgeReverse = splitPolygon(bridge, hole);
+
+    // filter collinear points around the cuts
+    var filteredBridge = filterPoints(bridge, bridge.next);
+    filterPoints(bridgeReverse, bridgeReverse.next);
+
+    // Check if input node was removed by the filtering
+    return outerNode === bridge ? filteredBridge : outerNode;
 }
 
 // David Eberly's algorithm for finding a bridge between hole and outer polygon
@@ -5494,7 +5455,7 @@ function initFillParsing(style) {
     };
 
     dataFuncs.forEach(([get, key]) => {
-      let val = get(null, feature);
+      const val = get(null, feature);
       buffers[key] = Array.from({ length }).flatMap(() => val);
     });
 
@@ -5510,7 +5471,7 @@ function triangulate(geometry) {
       return indexPolygon(coordinates);
     case "MultiPolygon":
       return coordinates.map(indexPolygon).reduce((acc, cur) => {
-        let indexShift = acc.vertices.length / 2;
+        const indexShift = acc.vertices.length / 2;
         acc.vertices.push(...cur.vertices);
         acc.indices.push(...cur.indices.map(h => h + indexShift));
         return acc;
@@ -5521,8 +5482,8 @@ function triangulate(geometry) {
 }
 
 function indexPolygon(coords) {
-  let { vertices, holes, dimensions } = earcut$1.flatten(coords);
-  let indices = earcut$1(vertices, holes, dimensions);
+  const { vertices, holes, dimensions } = earcut$1.flatten(coords);
+  const indices = earcut$1(vertices, holes, dimensions);
   return { vertices, indices };
 }
 
@@ -5534,14 +5495,14 @@ const ATLAS_PADDING = 1;
 const RECT_BUFFER = GLYPH_PBF_BORDER + ATLAS_PADDING;
 
 function layoutLine(glyphs, origin, spacing, scalar) {
-  var xCursor = origin[0];
+  let xCursor = origin[0];
   const y0 = origin[1];
 
   return glyphs.flatMap(g => {
-    let { left, top, advance } = g.metrics;
+    const { left, top, advance } = g.metrics;
 
-    let dx = xCursor + left - RECT_BUFFER;
-    let dy = y0 - top - RECT_BUFFER;
+    const dx = xCursor + left - RECT_BUFFER;
+    const dy = y0 - top - RECT_BUFFER;
 
     xCursor += advance + spacing;
 
@@ -5556,9 +5517,9 @@ function getGlyphInfo(feature, atlas) {
   if (!positions || !charCodes || !charCodes.length) return;
 
   const info = feature.charCodes.map(code => {
-    let pos = positions[code];
+    const pos = positions[code];
     if (!pos) return;
-    let { metrics, rect } = pos;
+    const { metrics, rect } = pos;
     return { code, metrics, rect };
   });
 
@@ -5641,14 +5602,14 @@ function getBreakPoints(glyphs, spacing, targetWidth) {
   let cursor = 0;
 
   glyphs.forEach((g, i) => {
-    let { code, metrics: { advance } } = g;
+    const { code, metrics: { advance } } = g;
     if (!whitespace[code]) cursor += advance + spacing;
 
     if (i == last) return;
     // if (!breakable[code]&& !charAllowsIdeographicBreaking(code)) return;
     if (!breakable[code]) return;
 
-    let breakInfo = evaluateBreak(
+    const breakInfo = evaluateBreak(
       i + 1,
       cursor,
       targetWidth,
@@ -5746,7 +5707,7 @@ function breakLines(glyphs, breakPoints) {
   let start = 0;
 
   return breakPoints.map(lineBreak => {
-    let line = glyphs.slice(start, lineBreak);
+    const line = glyphs.slice(start, lineBreak);
 
     // Trim whitespace from both ends
     while (line.length && whitespace[line[0].code]) line.shift();
@@ -5758,7 +5719,7 @@ function breakLines(glyphs, breakPoints) {
 }
 
 function trailingWhiteSpace(line) {
-  let len = line.length;
+  const len = line.length;
   if (!len) return false;
   return whitespace[line[len - 1].code];
 }
@@ -5794,8 +5755,8 @@ function initShaper(layout) {
     const justify = layout["text-justify"](zoom, feature);
     const lineShiftX = getLineShift(justify, boxShift[0]);
     const lineOrigins = lineWidths.map((lineWidth, i) => {
-      let x = (boxSize[0] - lineWidth) * lineShiftX + boxOrigin[0];
-      let y = i * lineHeight + boxOrigin[1];
+      const x = (boxSize[0] - lineWidth) * lineShiftX + boxOrigin[0];
+      const y = i * lineHeight + boxOrigin[1];
       return [x, y];
     });
 
@@ -5844,8 +5805,8 @@ function initShaping(style) {
     const buffers = shaper(feature, z, atlas);
     if (!buffers) return;
 
-    let { labelPos: [x0, y0], bbox } = buffers;
-    let box = {
+    const { labelPos: [x0, y0], bbox } = buffers;
+    const box = {
       minX: x0 + bbox[0],
       minY: y0 + bbox[1],
       maxX: x0 + bbox[2],
@@ -5859,7 +5820,7 @@ function initShaping(style) {
     buffers.tileCoords = Array.from({ length }).flatMap(() => [x, y, z]);
 
     dataFuncs.forEach(([get, key]) => {
-      let val = get(null, feature);
+      const val = get(null, feature);
       buffers[key] = Array.from({ length }).flatMap(() => val);
     });
 
@@ -6884,7 +6845,7 @@ function xhrErr(...strings) {
 
 function initUrlFunc(endpoints) {
   // Use a different endpoint for each request
-  var index = 0;
+  let index = 0;
 
   return function(z, x, y) {
     index = (index + 1) % endpoints.length;
@@ -7824,7 +7785,7 @@ function geojsonvtToJSON(value) {
 }
 
 const tasks = {};
-var loader, processor;
+let loader, processor;
 
 onmessage = function(msgEvent) {
   const { id, type, payload } = msgEvent.data;
@@ -7991,7 +7952,7 @@ function initCache({ create, size = 512 }) {
   }
 
   function drop(condition) {
-    var numTiles = 0;
+    let numTiles = 0;
     for (const id in tiles) {
       if (condition(tiles[id])) {
         tiles[id].cancel();
@@ -8006,11 +7967,10 @@ function initCache({ create, size = 512 }) {
 
 function initCaches({ context, glyphs }) {
   const queue = init$2();
-  const reporter = document.createElement("div");
 
   function addSource({ source, layers }) {
     const loader = initLoader(source, layers);
-    const factory = buildFactory({ loader, reporter });
+    const factory = buildFactory(loader);
     return initCache({ create: factory, size: 1.0 });
   }
 
@@ -8032,11 +7992,10 @@ function initCaches({ context, glyphs }) {
     addSource,
     sortTasks: queue.sortTasks,
     queuedTasks: queue.countTasks,
-    reporter,
   };
 }
 
-function buildFactory({ loader, reporter }) {
+function buildFactory(loader) {
   return function(z, x, y) {
     const id = [z, x, y].join("/");
     const tile = { z, x, y, id, priority: 0 };
@@ -8045,7 +8004,6 @@ function buildFactory({ loader, reporter }) {
       if (err) return; // console.log(err);
       tile.data = data;
       tile.ready = true;
-      reporter.dispatchEvent(new Event("tileLoaded"));
     }
 
     const getPriority = () => tile.priority;
@@ -8235,7 +8193,7 @@ function initTileGrid({ key, source, tileCache }) {
   const { tileSize = 512, maxzoom = 30 } = source;
   const outOfBounds = initBoundsCheck(source);
 
-  var numTiles = 0;
+  let numTiles = 0;
 
   // Set up the tile layout
   const layout = tile()
@@ -8257,7 +8215,7 @@ function initTileGrid({ key, source, tileCache }) {
     };
 
     // Retrieve a tile box for every tile in the grid
-    var tilesDone = 0;
+    let tilesDone = 0;
     const grid = tiles.map(([x, y, z]) => {
       const [xw, yw, zw] = tileWrap([x, y, z]);
 
@@ -8270,7 +8228,7 @@ function initTileGrid({ key, source, tileCache }) {
       if (!box) return;
 
       tilesDone += box.sw ** 2;
-      return Object.assign(box, { x, y, z });
+      return Object.assign(box, { x, xw, y, yw, z });
     }).filter(t => t !== undefined);
 
     grid.loaded = tilesDone / tiles.length;
@@ -8302,11 +8260,10 @@ function initSources(style, context, coords) {
     return grid;
   }).filter(s => s !== undefined);
 
-  function loadTilesets(pixRatio = 1) {
-    const transform = coords.getTransform(pixRatio);
-    const viewport = coords.getViewport(pixRatio);
+  function loadTilesets() {
+    const viewport = coords.getViewport();
+    const transform = coords.getTransform();
     grids.forEach(grid => {
-      // Make sure data from this source is still being displayed
       if (!grid.layers.some(l => l.visible)) return;
       tilesets[grid.key] = grid.getTiles(viewport, transform);
     });
@@ -8321,7 +8278,6 @@ function initSources(style, context, coords) {
     getLayerTiles: (layer) => tilesets[layerSources[layer]],
     loadTilesets,
     queuedTasks: caches.queuedTasks,
-    reporter: caches.reporter,
   };
 }
 
@@ -8591,7 +8547,7 @@ function initSelector(sources, projection) {
     const nTiles = 2 ** tileset[0].z;
     const [ix, iy] = projection.forward(point)
       .map(c => Math.floor(c * nTiles));
-    const tileBox = tileset.find(({ x, y }) => x == ix && y == iy);
+    const tileBox = tileset.find(({ xw, yw }) => xw == ix && yw == iy);
     if (!tileBox) return;
     const dataLayer = tileBox.tile.data.layers[layer];
     if (!dataLayer) return;
@@ -8648,7 +8604,6 @@ function init$3(userParams) {
     projection: params.projection,
     draw: () => null,
     select: () => null,
-    when: params.eventHandler.addListener,
   };
 
   // Extend with coordinate methods (SEE coords.js for API)
@@ -8663,9 +8618,6 @@ function init$3(userParams) {
 
 function setup$2(styleDoc, params, api) {
   const sources = initSources(styleDoc, params.context, api);
-  sources.reporter.addEventListener("tileLoaded",
-    () => params.eventHandler.emitEvent("tileLoaded"),
-    false);
 
   // Set up interactive toggling of layer visibility
   styleDoc.layers.forEach(l => {
@@ -8684,8 +8636,8 @@ function setup$2(styleDoc, params, api) {
   const render = initRenderer(params.context, styleDoc);
 
   api.draw = function(pixRatio = 1) {
-    const loadStatus = sources.loadTilesets(pixRatio);
-    render(sources.tilesets, api.getZoom(pixRatio), pixRatio);
+    const loadStatus = sources.loadTilesets();
+    render(sources.tilesets, api.getZoom(), pixRatio);
     return loadStatus;
   };
 
@@ -8698,12 +8650,12 @@ function initMap(params) {
   const { context, width, height, style, mapboxToken } = params;
   const framebuffer = context.initFramebuffer({ width, height });
 
-  return init$3({ context, framebuffer, style, mapboxToken, units: "radians" })
+  return init$3({ context, framebuffer, style, mapboxToken })
     .promise.then(api => setup$1(api, context, framebuffer.sampler));
 }
 
 function setup$1(api, context, sampler) {
-  var loadStatus = 0;
+  let loadStatus = 0;
 
   const texture = {
     sampler,
@@ -10186,7 +10138,12 @@ function setParams(userParams) {
     globeRadius = 6371,
     map,
     flipY = false,
+    units = "radians",
   } = userParams;
+
+  if (!context || !(context.gl instanceof WebGLRenderingContext)) {
+    throw "satellite-view: no valid WebGLRenderingContext!";
+  }
 
   const getPixelRatio = (pixelRatio)
     ? () => userParams.pixelRatio
@@ -10195,15 +10152,13 @@ function setParams(userParams) {
   //       NOT the property value at the time of getPixelRatio definition
   //  Thus, getPixelRatio will mirror any changes in the parent object
 
-  const maps = Array.isArray(map)
-    ? map
-    : [map];
+  const maps = Array.isArray(map) ? map : [map];
 
-  if (!context || !(context.gl instanceof WebGLRenderingContext)) {
-    throw "satellite-view: no valid WebGLRenderingContext!";
-  }
+  const unitsPerRad = (units === "degrees")
+    ? 180.0 / Math.PI
+    : 1.0;
 
-  return { context, getPixelRatio, globeRadius, maps, flipY };
+  return { context, getPixelRatio, globeRadius, maps, flipY, unitsPerRad };
 }
 
 var vertexSrc = `attribute vec4 aVertexPosition;
@@ -10412,18 +10367,19 @@ function buildShader(nLod) {
 function buildSelector(n) {
   // In the texLookup code, add lines to check each of the supplied textures,
   // and sample the highest LOD that contains the current coordinate
-  var selector = ``; // eslint-disable-line quotes
+  let selector = ``; // eslint-disable-line quotes
   while (--n) selector += `inside(coords[${n}])
     ? texture2D(samplers[${n}], coords[${n}])
     : `;
   return selector;
 }
 
-const maxMercLat = 2.0 * Math.atan( Math.exp(Math.PI) ) - Math.PI / 2.0;
-
 function init(userParams) {
+  const { PI, cos, sin, tan, atan, exp, min, max } = Math;
+  const maxMercLat = 2.0 * atan(exp(PI)) - PI / 2.0;
+
   const params = setParams(userParams);
-  const { context, maps, globeRadius } = params;
+  const { context, maps, globeRadius, unitsPerRad } = params;
 
   // Initialize shader program
   const shaders = buildShader(maps.length);
@@ -10445,15 +10401,15 @@ function init(userParams) {
     program.use();
 
     // Set uniforms related to camera position
-    const lat = camPos[1];
+    const lat = camPos[1] / unitsPerRad;
     setters.uLat0(lat);
-    setters.uCosLat0(Math.cos(lat));
-    setters.uSinLat0(Math.sin(lat));
-    setters.uTanLat0(Math.tan(lat));
+    setters.uCosLat0(cos(lat));
+    setters.uSinLat0(sin(lat));
+    setters.uTanLat0(tan(lat));
 
-    const clipLat = Math.min(Math.max(-maxMercLat, lat), maxMercLat);
+    const clipLat = min(max(-maxMercLat, lat), maxMercLat);
     setters.uLatErr(lat - clipLat);
-    setters.uExpY0(Math.tan(Math.PI / 4 + clipLat / 2));
+    setters.uExpY0(tan(PI / 4 + clipLat / 2));
 
     setters.uHnorm(camPos[2] / globeRadius);
     setters.uMaxRay(maxRayTan);
@@ -10464,11 +10420,8 @@ function init(userParams) {
 
     // Draw the globe
     const resized = context.resizeCanvasToDisplaySize(params.getPixelRatio());
-
     context.bindFramebufferAndSetViewport();
-
     context.gl.pixelStorei(context.gl.UNPACK_FLIP_Y_WEBGL, params.flipY);
-
     context.clear();
     context.draw({ vao });
 
@@ -10500,8 +10453,8 @@ function lonLatString(longitude, latitude) {
   return lonString + latString;
 }
 
-function degMinSec(radians) {
-  const deg = Math.abs(radians) * 180.0 / Math.PI;
+function degMinSec(degrees) {
+  const deg = Math.abs(degrees);
   const min = 60.0 * (deg - Math.floor(deg));
   const sec = 60.0 * (min - Math.floor(min));
 
@@ -10524,11 +10477,11 @@ function initMarkers(globe, container) {
     update: () => markerList.forEach(setPosition),
   };
 
-  function add({ element, type, lonLat, altitude }) {
+  function add({ element, type, position }) {
+    const [lon, lat, alt = 0.0] = position;
     const marker = {
       element: getMarkerElement(element, type),
-      // TODO: bad naming? lonLat includes altitude. Altitude currently unused
-      lonLat: new Float64Array([...lonLat, altitude || 0.0]),
+      position: new Float64Array([lon, lat, alt]),
       screenPos: new Float64Array(2),
     };
 
@@ -10570,7 +10523,7 @@ function initMarkers(globe, container) {
   }
 
   function setPosition(marker) {
-    const visible = globe.project(marker.screenPos, marker.lonLat);
+    const visible = globe.project(marker.screenPos, marker.position);
 
     Object.assign(marker.element.style, {
       display: (visible) ? "inline-block" : "none",
@@ -10589,18 +10542,18 @@ function initGlobe(userParams) {
 
 function setup(map, params) {
   const { globeDiv, toolTip, center, altitude, context } = params;
-  var requestID;
+  let requestID;
 
   const ball = init$1({
-    display: globeDiv, 
+    display: globeDiv,
     position: [center[0], center[1], altitude],
-    units: "radians",
   });
   const satView = init({
     context: context,
     globeRadius: ball.radius(),
     map: map.texture,
     flipY: false,
+    units: "degrees",
   });
   const markers = initMarkers(ball, globeDiv);
 
@@ -10633,7 +10586,7 @@ function setup(map, params) {
   }
 
   function update(time) {
-    var moving = ball.update(time * 0.001); // Convert time from ms to seconds
+    const moving = ball.update(time * 0.001); // Convert time from ms to seconds
 
     if (moving || map.loaded() < 1.0) {
       map.draw(ball.cameraPos(), ball.radius(), ball.view);

--- a/examples/geojson/index.html
+++ b/examples/geojson/index.html
@@ -18,10 +18,11 @@
   <script type="module">
     import * as globeletjs from "../../dist/globelet.js";
 
+    const degrees = 180.0 / Math.PI;
     globeletjs.initGlobe({
       container: 'globe',
       style: "./klokantech-basic-style-geojson.json",
-      center: [-100, 38.5],
+      center: [-100.0 / degrees, 38.5 / degrees],
       altitude: 6280,
     }).then(globe => {
       var spot;

--- a/examples/geojson/index.html
+++ b/examples/geojson/index.html
@@ -18,11 +18,10 @@
   <script type="module">
     import * as globeletjs from "../../dist/globelet.js";
 
-    const degrees = 180.0 / Math.PI;
     globeletjs.initGlobe({
       container: 'globe',
       style: "./klokantech-basic-style-geojson.json",
-      center: [-100.0 / degrees, 38.5 / degrees],
+      center: [-100.0, 38.5],
       altitude: 6280,
     }).then(globe => {
       var spot;
@@ -35,8 +34,8 @@
         // Check for a mountain under the cursor
         let mountain = globe.select("mountains", 12);
         if (mountain) {
-          let lonLat = mountain.geometry.coordinates;
-          spot = globe.addMarker({ lonLat, type: "spot" });
+          let position = mountain.geometry.coordinates;
+          spot = globe.addMarker({ position, type: "spot" });
         }
 
         requestID = requestAnimationFrame(animate);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "satellite-view": "^2.0.2",
-        "spinning-ball": "^0.2.5",
+        "spinning-ball": "github:GlobeletJS/spinning-ball",
         "tile-setter": "^0.0.7",
         "yawgl": "^0.3.2"
       },
@@ -1407,12 +1407,12 @@
     },
     "node_modules/spinning-ball": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.2.5.tgz",
-      "integrity": "sha512-BI1WEpv9wlpglp/sd0sl+1PVEYIOTIDw7Yh8pxUE+4JXpSuxN7A3eF8FJ5kWxtWXl7dvjbgqChM0g1nBTtlBSg==",
+      "resolved": "git+ssh://git@github.com/GlobeletJS/spinning-ball.git#6b930bf795e8def763486ccdd34be62727a0cedc",
+      "license": "MIT",
       "dependencies": {
         "gl-matrix": "^3.1.0",
-        "touch-sampler": "^0.0.2",
-        "yawgl": "^0.3.2"
+        "touch-sampler": "^0.0.3",
+        "yawgl": "^0.3.3"
       }
     },
     "node_modules/sprintf-js": {
@@ -1575,9 +1575,9 @@
       }
     },
     "node_modules/touch-sampler": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/touch-sampler/-/touch-sampler-0.0.2.tgz",
-      "integrity": "sha512-3AygOG3H3K3wTc/go9lgfJVplad2x/EVdiXivZqj253QYD01hAw4axJG1idNy+K+/h2+EE3pO9pP39JyIVXQZQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch-sampler/-/touch-sampler-0.0.3.tgz",
+      "integrity": "sha512-e7D1bWSxgwDCQ7wQlQUVfb5SyPikYu/LsiuHk0q0bGcVqeGUrcAy7GeyKM9wV8RpNZw+MsdR96qC/RhkR8pusg=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1660,9 +1660,9 @@
       "dev": true
     },
     "node_modules/yawgl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.3.2.tgz",
-      "integrity": "sha512-uf1RQei++6ydjFC5K1bOgsFUvyNm0C1+Y75wZOBj0oEd/0t2F5U/UJLZG7pTYAz7II8fpi2T9fnW2vfWfR0Ymg=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.3.3.tgz",
+      "integrity": "sha512-NhzKjhwcLk/BUchvYeFpnwI5RtHX7CemxZe9yeSz56QQy7SAyaFY8jvPfoNN4tNi+Jyl2k0qXxWqr7ucnIBAXA=="
     },
     "node_modules/zero-timeout": {
       "version": "0.0.5",
@@ -2717,13 +2717,12 @@
       }
     },
     "spinning-ball": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.2.5.tgz",
-      "integrity": "sha512-BI1WEpv9wlpglp/sd0sl+1PVEYIOTIDw7Yh8pxUE+4JXpSuxN7A3eF8FJ5kWxtWXl7dvjbgqChM0g1nBTtlBSg==",
+      "version": "git+ssh://git@github.com/GlobeletJS/spinning-ball.git#6b930bf795e8def763486ccdd34be62727a0cedc",
+      "from": "spinning-ball@GlobeletJS/spinning-ball",
       "requires": {
         "gl-matrix": "^3.1.0",
-        "touch-sampler": "^0.0.2",
-        "yawgl": "^0.3.2"
+        "touch-sampler": "^0.0.3",
+        "yawgl": "^0.3.3"
       }
     },
     "sprintf-js": {
@@ -2866,9 +2865,9 @@
       }
     },
     "touch-sampler": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/touch-sampler/-/touch-sampler-0.0.2.tgz",
-      "integrity": "sha512-3AygOG3H3K3wTc/go9lgfJVplad2x/EVdiXivZqj253QYD01hAw4axJG1idNy+K+/h2+EE3pO9pP39JyIVXQZQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch-sampler/-/touch-sampler-0.0.3.tgz",
+      "integrity": "sha512-e7D1bWSxgwDCQ7wQlQUVfb5SyPikYu/LsiuHk0q0bGcVqeGUrcAy7GeyKM9wV8RpNZw+MsdR96qC/RhkR8pusg=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -2933,9 +2932,9 @@
       "dev": true
     },
     "yawgl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.3.2.tgz",
-      "integrity": "sha512-uf1RQei++6ydjFC5K1bOgsFUvyNm0C1+Y75wZOBj0oEd/0t2F5U/UJLZG7pTYAz7II8fpi2T9fnW2vfWfR0Ymg=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.3.3.tgz",
+      "integrity": "sha512-NhzKjhwcLk/BUchvYeFpnwI5RtHX7CemxZe9yeSz56QQy7SAyaFY8jvPfoNN4tNi+Jyl2k0qXxWqr7ucnIBAXA=="
     },
     "zero-timeout": {
       "version": "0.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "globeletjs",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "globeletjs",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "satellite-view": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "satellite-view": "^2.0.2",
-        "spinning-ball": "github:GlobeletJS/spinning-ball",
-        "tile-setter": "^0.0.7",
-        "yawgl": "^0.3.2"
+        "satellite-view": "^2.1.0",
+        "spinning-ball": "^0.3.0",
+        "tile-setter": "^0.0.10",
+        "yawgl": "^0.3.3"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
         "eslint": "^7.30.0",
-        "eslint-config-globeletjs": "^0.0.5",
+        "eslint-config-globeletjs": "^0.0.6",
         "rollup": "^2.52.7"
       }
     },
@@ -394,11 +394,11 @@
       }
     },
     "node_modules/chunked-queue": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/chunked-queue/-/chunked-queue-0.1.3.tgz",
-      "integrity": "sha512-3qitqJhOxaGa2Z/onE0NftDhUxWcQke9Ke7oahKu7VXlX88upKxCdntjdk6XyLxX4wnz2JmeUyJfw+ZV80+Ufg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/chunked-queue/-/chunked-queue-0.1.4.tgz",
+      "integrity": "sha512-6t00FkVQxs8ldiePbftdCRmdzzo5kKUVVuPOqR5FheBvrIvpzI7ELsSx2ZkzTSobr/D0/ngqM/GIc01Dd2Hh7g==",
       "dependencies": {
-        "zero-timeout": "^0.0.5"
+        "zero-timeout": "^0.0.6"
       }
     },
     "node_modules/color-convert": {
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/eslint-config-globeletjs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-globeletjs/-/eslint-config-globeletjs-0.0.5.tgz",
-      "integrity": "sha512-4dCn5nEmEw/UcjU1afHwog4f0nheJxLSdKLrcvdji8JWKM3cqiVKvwno3v5e0rdYRNZ13IHUp9v+H5dfwVr0SA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-globeletjs/-/eslint-config-globeletjs-0.0.6.tgz",
+      "integrity": "sha512-CssCcLtILrIBLhbv3kJld/GrzSfWFpTkEaDh5bF0dHDKIxOZBOjGkGuWuljf+DFSOGcOTjDmEk0dCnntuRz7sQ==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -1337,14 +1337,14 @@
       }
     },
     "node_modules/satellite-view": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.0.2.tgz",
-      "integrity": "sha512-24IK84e09rkc2rRTbK3ltLPfrNlMPw4BC3Xs0PUXCcJ5kiMalGF+qLxcm0BA/loBTuPGEx+MFqWdTLC4LwvWRA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.1.0.tgz",
+      "integrity": "sha512-lEMjxFhSt2c6qnO6tcGochg2U3kK/i611CsQSQpyeL33+JU0p8V8iuws9CzhdX+KSCfnS3R8NaydzDDLeW7IQg=="
     },
     "node_modules/sdf-manager": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/sdf-manager/-/sdf-manager-0.0.8.tgz",
-      "integrity": "sha512-JUCt5ISyTwkgqsu6+eO6w3WzGUuo4RHLffui3rnTKPY25J8LOt3GIFiKXhFbm57jXodUoRDvRQIL9lN4MT8BcA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/sdf-manager/-/sdf-manager-0.0.9.tgz",
+      "integrity": "sha512-fBQc2YrWxsOZpzMKcq3l5sMP2d7xV1aoJx1TmzrHB0q1RVYckyR6HDn4kizI7WPV2cGOsSH7ClByrTEbRRksmQ==",
       "dependencies": {
         "potpack": "^1.0.1"
       },
@@ -1406,9 +1406,9 @@
       }
     },
     "node_modules/spinning-ball": {
-      "version": "0.2.5",
-      "resolved": "git+ssh://git@github.com/GlobeletJS/spinning-ball.git#6b930bf795e8def763486ccdd34be62727a0cedc",
-      "license": "MIT",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.3.0.tgz",
+      "integrity": "sha512-O2c4myk0NLk9ISYsxQsseEazh0SOVDK3gL43IbpqV8FVxL7f2zer39/gq4FUlFJiPhGV/Lx9AXYPLQMPvyLIjA==",
       "dependencies": {
         "gl-matrix": "^3.1.0",
         "touch-sampler": "^0.0.3",
@@ -1517,59 +1517,59 @@
       "dev": true
     },
     "node_modules/tile-gl": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.1.1.tgz",
-      "integrity": "sha512-Dnpyuu+fXMT1arywtn6304gByoNK2JEC/2sBC8XLO2A7xqmRd58lLwv+uvFs3q2LD1PueA3DJphjdCUR5DTy/g==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.1.3.tgz",
+      "integrity": "sha512-3y3tNvS0uJC2+uVPKdFJyraBU4uURr5Hxsmac+Et2sfd5peygSBKre+0Pe/T9gReOPgHeTSEeEB3KbqH3OpDgA==",
       "dependencies": {
-        "earcut": "^2.2.2",
-        "tile-labeler": "^0.2.2"
+        "earcut": "^2.2.3",
+        "tile-labeler": "^0.2.3"
       }
     },
     "node_modules/tile-labeler": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.2.2.tgz",
-      "integrity": "sha512-MTxy00t4cyHT865/CblMNWtQMX9DbFIpXK6VzmjtS/yCrZzSepYru1nZzPnqT+28+kJL7o/rDKZSCvFu1KN5xA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.2.3.tgz",
+      "integrity": "sha512-YIO/hgrQtD3p1/bzjMcP4QjQHxoc98amnRjFcxXFW2vXGQDxE9Vaju/xw6e46r2nxXgPkNQnXhu+68aDGqZNXQ==",
       "dependencies": {
-        "sdf-manager": "^0.0.8"
+        "sdf-manager": "^0.0.9"
       }
     },
     "node_modules/tile-mixer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tile-mixer/-/tile-mixer-0.1.1.tgz",
-      "integrity": "sha512-VL0QXiBeSgJnW6RRZtamLIHLe19wrj3w4fVWTbMS0K1boZTtkHhvM6LUsijKTMJugZnkqDuzVmu84Svo3mWJEA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tile-mixer/-/tile-mixer-0.1.2.tgz",
+      "integrity": "sha512-gNYLAOHw5yzhjSY+uztYQFk5qg/k2CSs0dncOiaWgXBBiDQmJ5LrkN/LRtAOwn5aTnrrKLhELIHailtqh+yb3w==",
       "dependencies": {
-        "chunked-queue": "^0.1.3",
+        "chunked-queue": "^0.1.4",
         "geojson-vt": "^3.2.1",
         "pbf": "^3.2.1",
         "rbush": "^3.0.1",
-        "tile-gl": "^0.1.1",
-        "tile-labeler": "^0.2.2",
-        "tile-stencil": "^0.4.3",
+        "tile-gl": "^0.1.3",
+        "tile-labeler": "^0.2.3",
+        "tile-stencil": "^0.4.4",
         "vector-tile-esm": "^2.1.2"
       }
     },
     "node_modules/tile-rack": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tile-rack/-/tile-rack-1.0.3.tgz",
-      "integrity": "sha512-AL8WI/P47eCw+aakeiscdMAgsUxauUZNvIpibc4QzjQUxLaoucuwRh6U3MwHp3eviXq8x07Kbfs9WBxOMn2mAA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tile-rack/-/tile-rack-1.0.4.tgz",
+      "integrity": "sha512-CcSLVJB4S7vJU/EAtxGpCXXVTFihDv9wanIXnI/mMg7LLtM1EwvdJljJUmZvRAnxgom1shhySKVcIfevIH5iKA=="
     },
     "node_modules/tile-setter": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.0.7.tgz",
-      "integrity": "sha512-kWM4ys+tkd3ja7WVDJspaIWShom3VUTfjqvNd0uXyYNMrJuVdisp1y5Lez3bPZU8VX8VGxjgZhask1VA2Dkl7w==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.0.10.tgz",
+      "integrity": "sha512-ip2s6TTVtJFoQ+D+DZKiKFgh6QVzJxyUNZ1u4z3NJp6+B9RdzLX3P8gy6uTtXTFC0pxEumA3ttYaAoMfsCj9HQ==",
       "dependencies": {
-        "chunked-queue": "^0.1.3",
+        "chunked-queue": "^0.1.4",
         "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-gl": "^0.1.1",
-        "tile-mixer": "^0.1.1",
-        "tile-rack": "^1.0.3",
-        "tile-stencil": "^0.4.3"
+        "tile-gl": "^0.1.3",
+        "tile-mixer": "^0.1.2",
+        "tile-rack": "^1.0.4",
+        "tile-stencil": "^0.4.4"
       }
     },
     "node_modules/tile-stencil": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.3.tgz",
-      "integrity": "sha512-dCK6L02ofm+SbVljxGho5UeAvxDOB5oiZdBRX2VdxdJLnexyqy8HaeNcDMQgrdFQBCdaMG14NUbpPO3tn1XTrw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.4.tgz",
+      "integrity": "sha512-oL3Rw/R3s79qGSRvWbpKZckae+3JD6QwEZzHaeOWN0AyXBBmXgTc+QRpJniz5NSUUjv5MoRJbEok68BMOsJLjA==",
       "dependencies": {
         "d3-color": "^1.4.1"
       }
@@ -1665,9 +1665,9 @@
       "integrity": "sha512-NhzKjhwcLk/BUchvYeFpnwI5RtHX7CemxZe9yeSz56QQy7SAyaFY8jvPfoNN4tNi+Jyl2k0qXxWqr7ucnIBAXA=="
     },
     "node_modules/zero-timeout": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/zero-timeout/-/zero-timeout-0.0.5.tgz",
-      "integrity": "sha512-1MAyHv/6Q2uC3mae6+msKUrQ1IX5Sj+d/ioSsweWWgcZsRs3yXoIvwS9AQBpYB0GUV9syuSANd6/IdY17UPwVw=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/zero-timeout/-/zero-timeout-0.0.6.tgz",
+      "integrity": "sha512-t/FOwjKCjk92wirEgWDVcCHjvsmm+f0WR+MNTkXlCjmAu+0rl8eMrtUihfVOHx+Gq3AGhxnO9VsYNQ39FjDk9g=="
     }
   },
   "dependencies": {
@@ -1944,11 +1944,11 @@
       }
     },
     "chunked-queue": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/chunked-queue/-/chunked-queue-0.1.3.tgz",
-      "integrity": "sha512-3qitqJhOxaGa2Z/onE0NftDhUxWcQke9Ke7oahKu7VXlX88upKxCdntjdk6XyLxX4wnz2JmeUyJfw+ZV80+Ufg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/chunked-queue/-/chunked-queue-0.1.4.tgz",
+      "integrity": "sha512-6t00FkVQxs8ldiePbftdCRmdzzo5kKUVVuPOqR5FheBvrIvpzI7ELsSx2ZkzTSobr/D0/ngqM/GIc01Dd2Hh7g==",
       "requires": {
-        "zero-timeout": "^0.0.5"
+        "zero-timeout": "^0.0.6"
       }
     },
     "color-convert": {
@@ -2097,9 +2097,9 @@
       }
     },
     "eslint-config-globeletjs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-globeletjs/-/eslint-config-globeletjs-0.0.5.tgz",
-      "integrity": "sha512-4dCn5nEmEw/UcjU1afHwog4f0nheJxLSdKLrcvdji8JWKM3cqiVKvwno3v5e0rdYRNZ13IHUp9v+H5dfwVr0SA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-globeletjs/-/eslint-config-globeletjs-0.0.6.tgz",
+      "integrity": "sha512-CssCcLtILrIBLhbv3kJld/GrzSfWFpTkEaDh5bF0dHDKIxOZBOjGkGuWuljf+DFSOGcOTjDmEk0dCnntuRz7sQ==",
       "dev": true
     },
     "eslint-scope": {
@@ -2669,14 +2669,14 @@
       }
     },
     "satellite-view": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.0.2.tgz",
-      "integrity": "sha512-24IK84e09rkc2rRTbK3ltLPfrNlMPw4BC3Xs0PUXCcJ5kiMalGF+qLxcm0BA/loBTuPGEx+MFqWdTLC4LwvWRA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.1.0.tgz",
+      "integrity": "sha512-lEMjxFhSt2c6qnO6tcGochg2U3kK/i611CsQSQpyeL33+JU0p8V8iuws9CzhdX+KSCfnS3R8NaydzDDLeW7IQg=="
     },
     "sdf-manager": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/sdf-manager/-/sdf-manager-0.0.8.tgz",
-      "integrity": "sha512-JUCt5ISyTwkgqsu6+eO6w3WzGUuo4RHLffui3rnTKPY25J8LOt3GIFiKXhFbm57jXodUoRDvRQIL9lN4MT8BcA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/sdf-manager/-/sdf-manager-0.0.9.tgz",
+      "integrity": "sha512-fBQc2YrWxsOZpzMKcq3l5sMP2d7xV1aoJx1TmzrHB0q1RVYckyR6HDn4kizI7WPV2cGOsSH7ClByrTEbRRksmQ==",
       "requires": {
         "potpack": "^1.0.1"
       }
@@ -2717,8 +2717,9 @@
       }
     },
     "spinning-ball": {
-      "version": "git+ssh://git@github.com/GlobeletJS/spinning-ball.git#6b930bf795e8def763486ccdd34be62727a0cedc",
-      "from": "spinning-ball@GlobeletJS/spinning-ball",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.3.0.tgz",
+      "integrity": "sha512-O2c4myk0NLk9ISYsxQsseEazh0SOVDK3gL43IbpqV8FVxL7f2zer39/gq4FUlFJiPhGV/Lx9AXYPLQMPvyLIjA==",
       "requires": {
         "gl-matrix": "^3.1.0",
         "touch-sampler": "^0.0.3",
@@ -2807,59 +2808,59 @@
       "dev": true
     },
     "tile-gl": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.1.1.tgz",
-      "integrity": "sha512-Dnpyuu+fXMT1arywtn6304gByoNK2JEC/2sBC8XLO2A7xqmRd58lLwv+uvFs3q2LD1PueA3DJphjdCUR5DTy/g==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.1.3.tgz",
+      "integrity": "sha512-3y3tNvS0uJC2+uVPKdFJyraBU4uURr5Hxsmac+Et2sfd5peygSBKre+0Pe/T9gReOPgHeTSEeEB3KbqH3OpDgA==",
       "requires": {
-        "earcut": "^2.2.2",
-        "tile-labeler": "^0.2.2"
+        "earcut": "^2.2.3",
+        "tile-labeler": "^0.2.3"
       }
     },
     "tile-labeler": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.2.2.tgz",
-      "integrity": "sha512-MTxy00t4cyHT865/CblMNWtQMX9DbFIpXK6VzmjtS/yCrZzSepYru1nZzPnqT+28+kJL7o/rDKZSCvFu1KN5xA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.2.3.tgz",
+      "integrity": "sha512-YIO/hgrQtD3p1/bzjMcP4QjQHxoc98amnRjFcxXFW2vXGQDxE9Vaju/xw6e46r2nxXgPkNQnXhu+68aDGqZNXQ==",
       "requires": {
-        "sdf-manager": "^0.0.8"
+        "sdf-manager": "^0.0.9"
       }
     },
     "tile-mixer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tile-mixer/-/tile-mixer-0.1.1.tgz",
-      "integrity": "sha512-VL0QXiBeSgJnW6RRZtamLIHLe19wrj3w4fVWTbMS0K1boZTtkHhvM6LUsijKTMJugZnkqDuzVmu84Svo3mWJEA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tile-mixer/-/tile-mixer-0.1.2.tgz",
+      "integrity": "sha512-gNYLAOHw5yzhjSY+uztYQFk5qg/k2CSs0dncOiaWgXBBiDQmJ5LrkN/LRtAOwn5aTnrrKLhELIHailtqh+yb3w==",
       "requires": {
-        "chunked-queue": "^0.1.3",
+        "chunked-queue": "^0.1.4",
         "geojson-vt": "^3.2.1",
         "pbf": "^3.2.1",
         "rbush": "^3.0.1",
-        "tile-gl": "^0.1.1",
-        "tile-labeler": "^0.2.2",
-        "tile-stencil": "^0.4.3",
+        "tile-gl": "^0.1.3",
+        "tile-labeler": "^0.2.3",
+        "tile-stencil": "^0.4.4",
         "vector-tile-esm": "^2.1.2"
       }
     },
     "tile-rack": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tile-rack/-/tile-rack-1.0.3.tgz",
-      "integrity": "sha512-AL8WI/P47eCw+aakeiscdMAgsUxauUZNvIpibc4QzjQUxLaoucuwRh6U3MwHp3eviXq8x07Kbfs9WBxOMn2mAA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tile-rack/-/tile-rack-1.0.4.tgz",
+      "integrity": "sha512-CcSLVJB4S7vJU/EAtxGpCXXVTFihDv9wanIXnI/mMg7LLtM1EwvdJljJUmZvRAnxgom1shhySKVcIfevIH5iKA=="
     },
     "tile-setter": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.0.7.tgz",
-      "integrity": "sha512-kWM4ys+tkd3ja7WVDJspaIWShom3VUTfjqvNd0uXyYNMrJuVdisp1y5Lez3bPZU8VX8VGxjgZhask1VA2Dkl7w==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.0.10.tgz",
+      "integrity": "sha512-ip2s6TTVtJFoQ+D+DZKiKFgh6QVzJxyUNZ1u4z3NJp6+B9RdzLX3P8gy6uTtXTFC0pxEumA3ttYaAoMfsCj9HQ==",
       "requires": {
-        "chunked-queue": "^0.1.3",
+        "chunked-queue": "^0.1.4",
         "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-gl": "^0.1.1",
-        "tile-mixer": "^0.1.1",
-        "tile-rack": "^1.0.3",
-        "tile-stencil": "^0.4.3"
+        "tile-gl": "^0.1.3",
+        "tile-mixer": "^0.1.2",
+        "tile-rack": "^1.0.4",
+        "tile-stencil": "^0.4.4"
       }
     },
     "tile-stencil": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.3.tgz",
-      "integrity": "sha512-dCK6L02ofm+SbVljxGho5UeAvxDOB5oiZdBRX2VdxdJLnexyqy8HaeNcDMQgrdFQBCdaMG14NUbpPO3tn1XTrw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.4.tgz",
+      "integrity": "sha512-oL3Rw/R3s79qGSRvWbpKZckae+3JD6QwEZzHaeOWN0AyXBBmXgTc+QRpJniz5NSUUjv5MoRJbEok68BMOsJLjA==",
       "requires": {
         "d3-color": "^1.4.1"
       }
@@ -2937,9 +2938,9 @@
       "integrity": "sha512-NhzKjhwcLk/BUchvYeFpnwI5RtHX7CemxZe9yeSz56QQy7SAyaFY8jvPfoNN4tNi+Jyl2k0qXxWqr7ucnIBAXA=="
     },
     "zero-timeout": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/zero-timeout/-/zero-timeout-0.0.5.tgz",
-      "integrity": "sha512-1MAyHv/6Q2uC3mae6+msKUrQ1IX5Sj+d/ioSsweWWgcZsRs3yXoIvwS9AQBpYB0GUV9syuSANd6/IdY17UPwVw=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/zero-timeout/-/zero-timeout-0.0.6.tgz",
+      "integrity": "sha512-t/FOwjKCjk92wirEgWDVcCHjvsmm+f0WR+MNTkXlCjmAu+0rl8eMrtUihfVOHx+Gq3AGhxnO9VsYNQ39FjDk9g=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "globeletjs",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Lightweight vector maps on a globe",
   "main": "dist/globelet-iife.js",
   "module": "dist/globelet.js",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "eslint": "^7.30.0",
-    "eslint-config-globeletjs": "^0.0.5",
+    "eslint-config-globeletjs": "^0.0.6",
     "rollup": "^2.52.7"
   },
   "dependencies": {
-    "satellite-view": "^2.0.2",
-    "spinning-ball": "github:GlobeletJS/spinning-ball",
-    "tile-setter": "^0.0.7",
-    "yawgl": "^0.3.2"
+    "satellite-view": "^2.1.0",
+    "spinning-ball": "^0.3.0",
+    "tile-setter": "^0.0.10",
+    "yawgl": "^0.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint --no-error-on-unmatched-pattern src examples/*/*.js",
     "build": "rollup -c build/rollup.config.js",
     "test": "npm run lint",
+    "postversion": "npm run build",
     "pretag": "npm run build && npm test",
     "tag": "git tag -s v$npm_package_version -m \"$npm_package_version\"",
     "prepublishOnly": "npm run tag && git push --tags"
@@ -42,7 +43,7 @@
   },
   "dependencies": {
     "satellite-view": "^2.0.2",
-    "spinning-ball": "^0.2.5",
+    "spinning-ball": "github:GlobeletJS/spinning-ball",
     "tile-setter": "^0.0.7",
     "yawgl": "^0.3.2"
   }

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,11 @@ function setup(map, params) {
   const { globeDiv, toolTip, center, altitude, context } = params;
   var requestID;
 
-  const ball = spinningBall.init(globeDiv, center, altitude);
+  const ball = spinningBall.init({
+    display: globeDiv, 
+    position: [center[0], center[1], altitude],
+    units: "radians",
+  });
   const satView = satelliteView.init({
     context: context,
     globeRadius: ball.radius(),
@@ -27,7 +31,7 @@ function setup(map, params) {
 
   return {
     mapLoaded: map.loaded,
-    select: (layer, dxy) => map.select(layer, ball.cursorPos, dxy),
+    select: (layer, dxy) => map.select(layer, ball.cursorPos(), dxy),
     showLayer: map.showLayer,
     hideLayer: map.hideLayer,
     getZoom: map.getZoom,
@@ -57,8 +61,8 @@ function setup(map, params) {
     var moving = ball.update(time * 0.001); // Convert time from ms to seconds
 
     if (moving || map.loaded() < 1.0) {
-      map.draw(ball.cameraPos, ball.radius(), ball.view);
-      satView.draw(ball.cameraPos, ball.view.maxRay);
+      map.draw(ball.cameraPos(), ball.radius(), ball.view);
+      satView.draw(ball.cameraPos(), ball.view.maxRay);
     }
 
     if (moving) markers.update();

--- a/src/main.js
+++ b/src/main.js
@@ -14,18 +14,18 @@ export function initGlobe(userParams) {
 
 function setup(map, params) {
   const { globeDiv, toolTip, center, altitude, context } = params;
-  var requestID;
+  let requestID;
 
   const ball = spinningBall.init({
-    display: globeDiv, 
+    display: globeDiv,
     position: [center[0], center[1], altitude],
-    units: "radians",
   });
   const satView = satelliteView.init({
     context: context,
     globeRadius: ball.radius(),
     map: map.texture,
     flipY: false,
+    units: "degrees",
   });
   const markers = initMarkers(ball, globeDiv);
 
@@ -58,7 +58,7 @@ function setup(map, params) {
   }
 
   function update(time) {
-    var moving = ball.update(time * 0.001); // Convert time from ms to seconds
+    const moving = ball.update(time * 0.001); // Convert time from ms to seconds
 
     if (moving || map.loaded() < 1.0) {
       map.draw(ball.cameraPos(), ball.radius(), ball.view);

--- a/src/map.js
+++ b/src/map.js
@@ -5,12 +5,12 @@ export function initMap(params) {
   const framebuffer = context.initFramebuffer({ width, height });
 
   return tileSetter
-    .init({ context, framebuffer, style, mapboxToken, units: "radians" })
+    .init({ context, framebuffer, style, mapboxToken })
     .promise.then(api => setup(api, context, framebuffer.sampler));
 }
 
 function setup(api, context, sampler) {
-  var loadStatus = 0;
+  let loadStatus = 0;
 
   const texture = {
     sampler,

--- a/src/map.js
+++ b/src/map.js
@@ -6,8 +6,7 @@ export function initMap(params) {
 
   return tileSetter
     .init({ context, framebuffer, style, mapboxToken, units: "radians" })
-    .promise.then(api => setup(api, context, framebuffer.sampler))
-    .catch(console.log);
+    .promise.then(api => setup(api, context, framebuffer.sampler));
 }
 
 function setup(api, context, sampler) {
@@ -37,7 +36,7 @@ function setup(api, context, sampler) {
     const k = 1.0 / dMap;
     const zoom = Math.log2(k) - 9;
 
-    api.setCenterZoom(camPos, zoom, "radians");
+    api.setCenterZoom(camPos, zoom);
     loadStatus = api.draw();
 
     texture.scale.set(api.getScale());
@@ -47,6 +46,6 @@ function setup(api, context, sampler) {
   }
 
   function select(layer, point, radius) {
-    return api.select({ layer, point, radius, units: "radians" });
+    return api.select({ layer, point, radius });
   }
 }

--- a/src/markers.js
+++ b/src/markers.js
@@ -7,11 +7,11 @@ export function initMarkers(globe, container) {
     update: () => markerList.forEach(setPosition),
   };
 
-  function add({ element, type, lonLat, altitude }) {
+  function add({ element, type, position }) {
+    const [lon, lat, alt = 0.0] = position;
     const marker = {
       element: getMarkerElement(element, type),
-      // TODO: bad naming? lonLat includes altitude. Altitude currently unused
-      lonLat: new Float64Array([...lonLat, altitude || 0.0]),
+      position: new Float64Array([lon, lat, alt]),
       screenPos: new Float64Array(2),
     };
 
@@ -53,7 +53,7 @@ export function initMarkers(globe, container) {
   }
 
   function setPosition(marker) {
-    const visible = globe.project(marker.screenPos, marker.lonLat);
+    const visible = globe.project(marker.screenPos, marker.position);
 
     Object.assign(marker.element.style, {
       display: (visible) ? "inline-block" : "none",

--- a/src/markers.js
+++ b/src/markers.js
@@ -53,7 +53,7 @@ export function initMarkers(globe, container) {
   }
 
   function setPosition(marker) {
-    const visible = globe.lonLatToScreenXY(marker.screenPos, marker.lonLat);
+    const visible = globe.project(marker.screenPos, marker.lonLat);
 
     Object.assign(marker.element.style, {
       display: (visible) ? "inline-block" : "none",

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -3,11 +3,12 @@ export function printToolTip(toolTip, ball) {
   if (!toolTip) return;
 
   // Print altitude and lon/lat of camera
-  const alt = ball.cameraPos[2].toPrecision(5);
-  toolTip.innerHTML = alt + "km " + lonLatString(...ball.cameraPos);
+  const cameraPos = ball.cameraPos();
+  const alt = cameraPos[2].toPrecision(5);
+  toolTip.innerHTML = alt + "km " + lonLatString(...cameraPos);
 
   if (ball.isOnScene()) {
-    toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos);
+    toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos());
   }
 }
 

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -22,8 +22,8 @@ function lonLatString(longitude, latitude) {
   return lonString + latString;
 }
 
-function degMinSec(radians) {
-  const deg = Math.abs(radians) * 180.0 / Math.PI;
+function degMinSec(degrees) {
+  const deg = Math.abs(degrees);
   const min = 60.0 * (deg - Math.floor(deg));
   const sec = 60.0 * (min - Math.floor(min));
 


### PR DESCRIPTION
This PR addresses #10.

Camera and cursor coordinates from [spinning-ball](https://github.com/GlobeletJS/spinning-ball) can now be reported in degrees. This PR incorporates the latest spinning-ball, and sets degrees as the default unit for cameraPos, cursorPos, and marker.position.

Along the way, I fixed a bug in [tile-setter](https://github.com/GlobeletJS/tile-setter) that was messing up feature selection across the antimeridian.