### PR TITLE
Accept a link to a container Element, OR its string ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ const globePromise = globeletjs.initGlobe(params);
 ```
 
 The `params` object supplied to initGlobe can have the following properties:
-- `container` (REQUIRED): The [ID][] of an [HTML DIV element][] where the 
-  globe will be displayed
+- `container` (REQUIRED): An [HTML DIV element][] (or its string [ID][]) where
+  the globe will be displayed
 - `style` (REQUIRED): A link to a [MapLibre style document][Maplibre] 
   describing the map to be rendered. Please see below for some notes about
   [supported map styles](#supported-map-styles).

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -225,7 +225,7 @@ var globeletjs = (function (exports) {
     gl.linkProgram(program);
 
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-      fail$3("Unable to link the program", gl.getProgramInfoLog(program));
+      fail$4("Unable to link the program", gl.getProgramInfoLog(program));
     }
 
     const { constantSetters, constructVao } = initAttributes(gl, program);
@@ -246,13 +246,13 @@ var globeletjs = (function (exports) {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
       const log = gl.getShaderInfoLog(shader);
       gl.deleteShader(shader);
-      fail$3("An error occured compiling the shader", log);
+      fail$4("An error occured compiling the shader", log);
     }
 
     return shader;
   }
 
-  function fail$3(msg, log) {
+  function fail$4(msg, log) {
     throw Error("yawgl.initProgram: " + msg + ":\n" + log);
   }
 
@@ -522,15 +522,17 @@ var globeletjs = (function (exports) {
 
   function setParams$3(userParams) {
     // Get the containing DIV element, and set its CSS class
-    const container = document.getElementById(userParams.container);
-    container.classList.add("globelet");
+    const container = (typeof userParams.container === "string")
+      ? document.getElementById(userParams.container)
+      : userParams.container;
+    if (!(container instanceof Element)) fail$3("missing container element");
     if (container.clientWidth <= 64 || container.clientHeight <= 64) {
-      throw Error("GlobeletJS: container must be at least 64x64 pixels!");
+      fail$3("container must be at least 64x64 pixels");
     }
+    container.classList.add("globelet");
 
     // Add Elements for globe interface, svg sprite, status bar, canvas
     const globeDiv = addChild("div", "main", container);
-    globeDiv.id = "globe"; // TEMPORARY: For backwards compatibility
     globeDiv.insertAdjacentHTML("afterbegin", sprite);
     const toolTip = addChild( "div", "status", globeDiv);
     const canvas = addChild("canvas", "map", globeDiv);
@@ -565,6 +567,10 @@ var globeletjs = (function (exports) {
       child.className = className;
       return parentElement.appendChild(child);
     }
+  }
+
+  function fail$3(message) {
+    throw Error("GlobeletJS: " + message);
   }
 
   const { cos, tan, atan, exp, log, PI, min, max } = Math;
@@ -10583,6 +10589,7 @@ precision highp sampler2D;
 
       destroy: () => (satView.destroy(), globeDiv.remove()),
       breakLoop: 0,
+      version: params.version,
     };
 
     function animate(time) {

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -464,7 +464,7 @@ var globeletjs = (function (exports) {
     }
   }
 
-  var version = "0.1.1";
+  var version = "0.1.2";
 
   var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="sprite">
   <!--Default image for favicon-->

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -222,7 +222,7 @@ function initProgram(gl, vertexSrc, fragmentSrc) {
   gl.linkProgram(program);
 
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-    fail$3("Unable to link the program", gl.getProgramInfoLog(program));
+    fail$4("Unable to link the program", gl.getProgramInfoLog(program));
   }
 
   const { constantSetters, constructVao } = initAttributes(gl, program);
@@ -243,13 +243,13 @@ function loadShader(gl, type, source) {
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
     const log = gl.getShaderInfoLog(shader);
     gl.deleteShader(shader);
-    fail$3("An error occured compiling the shader", log);
+    fail$4("An error occured compiling the shader", log);
   }
 
   return shader;
 }
 
-function fail$3(msg, log) {
+function fail$4(msg, log) {
   throw Error("yawgl.initProgram: " + msg + ":\n" + log);
 }
 
@@ -519,15 +519,17 @@ var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" clas
 
 function setParams$3(userParams) {
   // Get the containing DIV element, and set its CSS class
-  const container = document.getElementById(userParams.container);
-  container.classList.add("globelet");
+  const container = (typeof userParams.container === "string")
+    ? document.getElementById(userParams.container)
+    : userParams.container;
+  if (!(container instanceof Element)) fail$3("missing container element");
   if (container.clientWidth <= 64 || container.clientHeight <= 64) {
-    throw Error("GlobeletJS: container must be at least 64x64 pixels!");
+    fail$3("container must be at least 64x64 pixels");
   }
+  container.classList.add("globelet");
 
   // Add Elements for globe interface, svg sprite, status bar, canvas
   const globeDiv = addChild("div", "main", container);
-  globeDiv.id = "globe"; // TEMPORARY: For backwards compatibility
   globeDiv.insertAdjacentHTML("afterbegin", sprite);
   const toolTip = addChild( "div", "status", globeDiv);
   const canvas = addChild("canvas", "map", globeDiv);
@@ -562,6 +564,10 @@ function setParams$3(userParams) {
     child.className = className;
     return parentElement.appendChild(child);
   }
+}
+
+function fail$3(message) {
+  throw Error("GlobeletJS: " + message);
 }
 
 const { cos, tan, atan, exp, log, PI, min, max } = Math;
@@ -10580,6 +10586,7 @@ function setup(map, params) {
 
     destroy: () => (satView.destroy(), globeDiv.remove()),
     breakLoop: 0,
+    version: params.version,
   };
 
   function animate(time) {

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -461,7 +461,7 @@ function initContext(gl) {
   }
 }
 
-var version = "0.1.1";
+var version = "0.1.2";
 
 var sprite = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="sprite">
   <!--Default image for favicon-->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "globeletjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "globeletjs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "satellite-view": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "globeletjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Lightweight vector maps on a globe",
   "main": "dist/globelet-iife.js",
   "module": "dist/globelet.js",

--- a/src/main.js
+++ b/src/main.js
@@ -50,6 +50,7 @@ function setup(map, params) {
 
     destroy: () => (satView.destroy(), globeDiv.remove()),
     breakLoop: 0,
+    version: params.version,
   };
 
   function animate(time) {

--- a/src/params.js
+++ b/src/params.js
@@ -4,15 +4,17 @@ import sprite from "../dist/globelet.svg";
 
 export function setParams(userParams) {
   // Get the containing DIV element, and set its CSS class
-  const container = document.getElementById(userParams.container);
-  container.classList.add("globelet");
+  const container = (typeof userParams.container === "string")
+    ? document.getElementById(userParams.container)
+    : userParams.container;
+  if (!(container instanceof Element)) fail("missing container element");
   if (container.clientWidth <= 64 || container.clientHeight <= 64) {
-    throw Error("GlobeletJS: container must be at least 64x64 pixels!");
+    fail("container must be at least 64x64 pixels");
   }
+  container.classList.add("globelet");
 
   // Add Elements for globe interface, svg sprite, status bar, canvas
   const globeDiv = addChild("div", "main", container);
-  globeDiv.id = "globe"; // TEMPORARY: For backwards compatibility
   globeDiv.insertAdjacentHTML("afterbegin", sprite);
   const toolTip = addChild( "div", "status", globeDiv);
   const canvas = addChild("canvas", "map", globeDiv);
@@ -47,4 +49,8 @@ export function setParams(userParams) {
     child.className = className;
     return parentElement.appendChild(child);
   }
+}
+
+function fail(message) {
+  throw Error("GlobeletJS: " + message);
 }


### PR DESCRIPTION
This PR addresses #14 . It extends the "container" parameter of the `initGlobe` method to accept either an HTML Element, OR a string ID for that element. It also adds a check for the validity of the "container", with an appropriate error message.

I updated the README to clarify.

If approved, I think this could be a semver PATCH (bugfix), since the proposed behavior is probably expected by most people (it is how MapLibre works).