### PR TITLE
Fix bugs affecting Android phones

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -1,22 +1,20 @@
-import resolve from '@rollup/plugin-node-resolve';
-import json from '@rollup/plugin-json';
+import resolve from "@rollup/plugin-node-resolve";
 import { svg } from "./svg-plugin.js";
 import pkg from "../package.json";
 
 export default {
-  input: 'src/main.js',
+  input: "src/main.js",
   plugins: [
     resolve(),
     svg(),
-    json(),
   ],
   output: [{
     file: pkg.module,
-    format: 'esm',
+    format: "esm",
     name: pkg.name
   }, {
     file: pkg.main,
-    format: 'iife',
+    format: "iife",
     name: pkg.name
   }],
 };

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -173,8 +173,9 @@ var globeletjs = (function (exports) {
     }
 
     function buildTextureSetter(bindPoint) {
+      gl.uniform1i(loc, textureUnit);
+
       return function(texture) {
-        gl.uniform1i(loc, textureUnit);
         gl.activeTexture(gl.TEXTURE0 + textureUnit);
         gl.bindTexture(bindPoint, texture);
       };
@@ -182,8 +183,9 @@ var globeletjs = (function (exports) {
 
     function buildTextureArraySetter(bindPoint) {
       const units = Array.from(Array(size), () => textureUnit++);
+      gl.uniform1iv(loc, units);
+
       return function(textures) {
-        gl.uniform1iv(loc, units);
         textures.forEach((texture, i) => {
           gl.activeTexture(gl.TEXTURE0 + units[i]);
           gl.bindTexture(bindPoint, texture);
@@ -200,7 +202,10 @@ var globeletjs = (function (exports) {
       .filter(info => info !== undefined);
 
     const textureTypes = [gl.SAMPLER_2D, gl.SAMPLER_CUBE];
-    let textureUnit = 0;
+    let textureUnit = 1; // Skip the first texture unit: used for initTexture
+
+    // Make sure program is active, in case we need to set texture units
+    gl.useProgram(program);
 
     return uniformInfo.reduce((d, info) => {
       const { name, type, size } = info;
@@ -216,27 +221,27 @@ var globeletjs = (function (exports) {
   }
 
   function initAttributes(gl, program) {
-    // Construct a dictionary of the indices of each attribute used by program
+    // Construct a dictionary of the locations of each attribute in the program
     const attrIndices = Array
       .from({ length: gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES) })
-      .map((v, i) => gl.getActiveAttrib(program, i))
-      .reduce((d, { name }, index) => (d[name] = index, d), {});
+      .map((v, i) => gl.getActiveAttrib(program, i).name)
+      .reduce((d, n) => (d[n] = gl.getAttribLocation(program, n), d), {});
 
     // Construct a dictionary of functions to set a constant value for a given
     // vertex attribute, when a per-vertex buffer is not needed
     const constantSetters = Object.entries(attrIndices).reduce((d, [name, i]) => {
       d[name] = function(v) {
         gl.disableVertexAttribArray(i);
-
-        // For float attributes, the supplied value may be a Number
-        if (v.length === undefined) return gl.vertexAttrib1f(i, v);
-
-        if (![1, 2, 3, 4].includes(v.length)) return;
-        const methodName = "vertexAttrib" + v.length + "fv";
-        gl[methodName](i, v);
+        const method = getConstMethod(v.length);
+        if (method) gl[method](i, v);
       };
       return d;
     }, {});
+
+    function getConstMethod(len) {
+      if (len === undefined) return "vertexAttrib1f";
+      if ([1, 2, 3, 4].includes(len)) return "vertexAttrib" + len + "fv";
+    }
 
     function constructVao({ attributes, indices }) {
       const vao = gl.createVertexArray();
@@ -401,6 +406,9 @@ var globeletjs = (function (exports) {
       const { width = 1, height = 1 } = (image) ? image : options;
 
       const texture = gl.createTexture();
+
+      // Work with first texture unit. Leave others unchanged (may be in use)
+      gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(target, texture);
 
       gl.texParameteri(target, gl.TEXTURE_WRAP_S, wrapS);
@@ -1002,7 +1010,6 @@ in vec3 tileCoords;
 
 uniform vec4 mapCoords;   // x, y, z, extent of tileset[0]
 uniform vec3 mapShift;    // translate and scale of tileset[0]
-
 uniform vec4 screenScale; // 2 / width, -2 / height, pixRatio, cameraScale
 
 vec2 tileToMap(vec2 tilePos) {
@@ -1047,28 +1054,70 @@ float styleScale(vec2 tilePos) {
 }
 `;
 
+  var defaultPreamble = `#version 300 es
+
+precision highp float;
+
+uniform vec4 screenScale; // 2 / width, -2 / height, pixRatio, cameraScale
+
+vec2 tileToMap(vec2 tilePos) {
+  return tilePos * screenScale.z;
+}
+
+vec4 mapToClip(vec2 mapPos, float z) {
+  vec2 projected = mapPos * screenScale.xy + vec2(-1.0, 1.0);
+  return vec4(projected, z, 1.0);
+}
+
+float styleScale(vec2 tilePos) {
+  return screenScale.z;
+}
+`;
+
   function setParams$2(userParams) {
     const {
-      context, framebuffer,
-      projScale = false,
-      multiTile = true,
+      context, framebuffer, extraAttributes,
+      preamble = defaultPreamble,
     } = userParams;
 
-    const scaleCode = (projScale) ? mercatorScale : simpleScale;
-    const size = framebuffer.size;
+    return { context, framebuffer, preamble, extraAttributes };
+  }
 
-    context.clipRectFlipY = function(x, y, w, h) {
-      const yflip = size.height - y - h;
-      context.clipRect(x, yflip, w, h);
-    };
+  var vert$4 = `in vec2 quadPos;
+
+void main() {
+  gl_Position = vec4(quadPos, 0.0, 1.0);
+}
+`;
+
+  var frag$4 = `#version 300 es
+
+precision mediump float;
+
+uniform vec4 backgroundColor;
+uniform float backgroundOpacity;
+
+out vec4 pixColor;
+
+void main() {
+  float alpha = backgroundColor.a * backgroundOpacity;
+  pixColor = vec4(backgroundColor.rgb * alpha, alpha);
+}
+`;
+
+  function initBackground(context) {
+    const quadPos = context.initQuad();
+
+    const styleKeys = ["background-color", "background-opacity"];
 
     return {
-      context, framebuffer, multiTile,
-      preamble: preamble + scaleCode,
+      vert: vert$4, frag: frag$4, styleKeys,
+      getSpecialAttrs: () => ({ quadPos }),
+      countInstances: () => 1,
     };
   }
 
-  var vert$4 = `in vec2 quadPos; // Vertices of the quad instance
+  var vert$3 = `in vec2 quadPos; // Vertices of the quad instance
 in vec2 circlePos;
 in float circleRadius;
 in vec4 circleColor;
@@ -1093,7 +1142,7 @@ void main() {
 }
 `;
 
-  var frag$4 = `#version 300 es
+  var frag$3 = `#version 300 es
 
 precision mediump float;
 
@@ -1115,7 +1164,6 @@ void main() {
   function initCircle(context) {
     const attrInfo = {
       circlePos: { numComponents: 2 },
-      tileCoords: { numComponents: 3 },
       circleRadius: { numComponents: 1 },
       circleColor: { numComponents: 4 },
       circleOpacity: { numComponents: 1 },
@@ -1125,13 +1173,13 @@ void main() {
     const styleKeys = ["circle-radius", "circle-color", "circle-opacity"];
 
     return {
-      vert: vert$4, frag: frag$4, attrInfo, styleKeys,
+      vert: vert$3, frag: frag$3, attrInfo, styleKeys,
       getSpecialAttrs: () => ({ quadPos }),
       countInstances: (buffers) => buffers.circlePos.length / 2,
     };
   }
 
-  var vert$3 = `in vec2 quadPos;
+  var vert$2 = `in vec2 quadPos;
 in vec3 pointA, pointB, pointC, pointD;
 in vec4 lineColor;
 in float lineOpacity, lineWidth, lineGapWidth;
@@ -1245,7 +1293,7 @@ void main() {
 }
 `;
 
-  var frag$3 = `#version 300 es
+  var frag$2 = `#version 300 es
 
 precision highp float;
 
@@ -1305,7 +1353,6 @@ void main() {
     const { initQuad, createBuffer, initAttribute } = context;
 
     const attrInfo = {
-      tileCoords: { numComponents: 3 },
       lineColor: { numComponents: 4 },
       lineOpacity: { numComponents: 1 },
       lineWidth: { numComponents: 1 },
@@ -1349,12 +1396,12 @@ void main() {
     ];
 
     return {
-      vert: vert$3, frag: frag$3, attrInfo, styleKeys, getSpecialAttrs,
+      vert: vert$2, frag: frag$2, attrInfo, styleKeys, getSpecialAttrs,
       countInstances: (buffers) => buffers.lines.length / numComponents - 3,
     };
   }
 
-  var vert$2 = `in vec2 position;
+  var vert$1 = `in vec2 position;
 in vec4 fillColor;
 in float fillOpacity;
 
@@ -1371,7 +1418,7 @@ void main() {
 }
 `;
 
-  var frag$2 = `#version 300 es
+  var frag$1 = `#version 300 es
 
 precision mediump float;
 
@@ -1387,7 +1434,6 @@ void main() {
   function initFill() {
     const attrInfo = {
       position: { numComponents: 2, divisor: 0 },
-      tileCoords: { numComponents: 3, divisor: 0 },
       fillColor: { numComponents: 4, divisor: 0 },
       fillOpacity: { numComponents: 1, divisor: 0 },
     };
@@ -1395,95 +1441,39 @@ void main() {
     const styleKeys = ["fill-color", "fill-opacity", "fill-translate"];
 
     return {
-      vert: vert$2, frag: frag$2, attrInfo, styleKeys,
+      vert: vert$1, frag: frag$1, attrInfo, styleKeys,
       getSpecialAttrs: () => ({}),
     };
   }
 
-  var vert$1 = `in vec2 quadPos;    // Vertices of the quad instance
-in vec3 labelPos0;   // x, y, angle
-in vec4 spritePos;  // dx, dy (relative to labelPos0), w, h
-in vec4 spriteRect; // x, y, w, h
+  var vert = `in vec2 quadPos;   // Vertices of the quad instance
+in vec4 labelPos;  // x, y, angle, font size scalar (0 for icons)
+in vec4 glyphPos;  // dx, dy (relative to labelPos), w, h
+in vec4 glyphRect; // x, y, w, h
+
 in float iconOpacity;
 
-out float opacity;
-out vec2 texCoord;
-
-void main() {
-  texCoord = spriteRect.xy + spriteRect.zw * quadPos;
-  opacity = iconOpacity;
-
-  vec2 mapPos = tileToMap(labelPos0.xy);
-
-  // Shift to the appropriate corner of the current instance quad
-  vec2 dPos = (spritePos.xy + spritePos.zw * quadPos) * styleScale(labelPos0.xy);
-
-  float cos_a = cos(labelPos0.z);
-  float sin_a = sin(labelPos0.z);
-  float dx = dPos.x * cos_a - dPos.y * sin_a;
-  float dy = dPos.x * sin_a + dPos.y * cos_a;
-
-  gl_Position = mapToClip(mapPos + vec2(dx, dy), 0.0);
-}
-`;
-
-  var frag$1 = `#version 300 es
-
-precision highp float;
-
-uniform sampler2D sprite;
-
-in float opacity;
-in vec2 texCoord;
-
-out vec4 pixColor;
-
-void main() {
-  vec4 texColor = texture(sprite, texCoord);
-  // Input sprite does NOT have pre-multiplied alpha
-  pixColor = vec4(texColor.rgb * texColor.a, texColor.a) * opacity;
-}
-`;
-
-  function initSprite(context) {
-    const attrInfo = {
-      labelPos0: { numComponents: 3 },
-      spritePos: { numComponents: 4 },
-      spriteRect: { numComponents: 4 },
-      tileCoords: { numComponents: 3 },
-      iconOpacity: { numComponents: 1 },
-    };
-    const quadPos = context.initQuad({ x0: 0.0, y0: 0.0, x1: 1.0, y1: 1.0 });
-
-    const styleKeys = ["icon-opacity"];
-
-    return {
-      vert: vert$1, frag: frag$1, attrInfo, styleKeys,
-      getSpecialAttrs: () => ({ quadPos }),
-      countInstances: (buffers) => buffers.labelPos0.length / 3,
-    };
-  }
-
-  var vert = `in vec2 quadPos;  // Vertices of the quad instance
-in vec4 labelPos; // x, y, angle, font size scalar
-in vec4 charPos;  // dx, dy (relative to labelPos), w, h
-in vec4 sdfRect;  // x, y, w, h
 in vec4 textColor;
 in float textOpacity;
 in float textHaloBlur;
 in vec4 textHaloColor;
 in float textHaloWidth;
 
+out vec2 texCoord;
+
+out float opacity;
+
 out vec4 fillColor;
 out vec4 haloColor;
 out vec2 haloSize; // width, blur
-out vec2 texCoord;
 out float taperWidth;
 
 void main() {
-  texCoord = sdfRect.xy + sdfRect.zw * quadPos;
+  // For icons only
+  opacity = iconOpacity;
 
-  taperWidth = labelPos.w * screenScale.z;
+  // For text only
+  taperWidth = labelPos.w * screenScale.z; // == 0.0 for icon glyphs
   haloSize = vec2(textHaloWidth, textHaloBlur) * screenScale.z;
 
   float fillAlpha = textColor.a * textOpacity;
@@ -1491,10 +1481,14 @@ void main() {
   float haloAlpha = textHaloColor.a * textOpacity;
   haloColor = vec4(textHaloColor.rgb * haloAlpha, haloAlpha);
 
+  // Texture coordinates
+  texCoord = glyphRect.xy + glyphRect.zw * quadPos;
+
+  // Compute glyph position. First transform the label origin
   vec2 mapPos = tileToMap(labelPos.xy);
 
   // Shift to the appropriate corner of the current instance quad
-  vec2 dPos = (charPos.xy + charPos.zw * quadPos) * styleScale(labelPos.xy);
+  vec2 dPos = (glyphPos.xy + glyphPos.zw * quadPos) * styleScale(labelPos.xy);
 
   float cos_a = cos(labelPos.z);
   float sin_a = sin(labelPos.z);
@@ -1509,17 +1503,26 @@ void main() {
 
 precision highp float;
 
-uniform sampler2D sdf;
+uniform sampler2D sprite, sdf;
+
+in vec2 texCoord;
+
+in float opacity;
 
 in vec4 fillColor;
 in vec4 haloColor;
 in vec2 haloSize; // width, blur
-in vec2 texCoord;
-in float taperWidth;
+in float taperWidth; // 0 for icons
 
 out vec4 pixColor;
 
 void main() {
+  // Get color from sprite if this is an icon glyph
+  vec4 spritePix = texture(sprite, texCoord);
+  // Input sprite does NOT have pre-multiplied alpha
+  vec4 iconColor = vec4(spritePix.rgb * spritePix.a, spritePix.a) * opacity;
+
+  // Compute fill and halo color from sdf if this is a text glyph
   float sdfVal = texture(sdf, texCoord).a;
   float screenDist = taperWidth * (191.0 - 255.0 * sdfVal) / 32.0;
 
@@ -1529,17 +1532,19 @@ void main() {
   float haloAlpha = (haloSize.x > 0.0 || haloSize.y > 0.0)
     ? (1.0 - fillAlpha) * smoothstep(-hTaper, -hEdge, -screenDist)
     : 0.0;
+  vec4 textColor = fillColor * fillAlpha + haloColor * haloAlpha;
 
-  pixColor = fillColor * fillAlpha + haloColor * haloAlpha;
+  // Choose icon or text color based on taperWidth value
+  pixColor = (taperWidth == 0.0) ? iconColor : textColor;
 }
 `;
 
-  function initText(context) {
+  function initSymbol(context) {
     const attrInfo = {
       labelPos: { numComponents: 4 },
-      charPos: { numComponents: 4 },
-      sdfRect: { numComponents: 4 },
-      tileCoords: { numComponents: 3 },
+      glyphPos: { numComponents: 4 },
+      glyphRect: { numComponents: 4 },
+      iconOpacity: { numComponents: 1 },
       textColor: { numComponents: 4 },
       textOpacity: { numComponents: 1 },
       textHaloBlur: { numComponents: 1 },
@@ -1549,6 +1554,7 @@ void main() {
     const quadPos = context.initQuad({ x0: 0.0, y0: 0.0, x1: 1.0, y1: 1.0 });
 
     const styleKeys = [
+      "icon-opacity",
       "text-color",
       "text-opacity",
       "text-halo-blur",
@@ -1563,12 +1569,14 @@ void main() {
     };
   }
 
-  function initLoader(context, progInfo, constructVao) {
+  function initLoader(context, info, constructVao, extraAttributes) {
     const { initAttribute, initIndices } = context;
-    const { attrInfo, getSpecialAttrs, countInstances } = progInfo;
+    const { attrInfo, getSpecialAttrs, countInstances } = info;
+
+    const allAttrs = Object.assign({}, attrInfo, extraAttributes);
 
     function getAttributes(buffers) {
-      return Object.entries(attrInfo).reduce((d, [key, info]) => {
+      return Object.entries(allAttrs).reduce((d, [key, info]) => {
         const data = buffers[key];
         if (data) d[key] = initAttribute(Object.assign({ data }, info));
         return d;
@@ -1591,43 +1599,44 @@ void main() {
     return (countInstances) ? loadInstanced : loadIndexed;
   }
 
-  function initGrid(use, uniformSetters, framebuffer) {
-    const { screenScale, mapCoords, mapShift } = uniformSetters;
+  function compilePrograms(params) {
+    const { context, preamble, extraAttributes } = params;
 
-    function setScreen(pixRatio = 1.0, cameraScale = 1.0) {
-      const { width, height } = framebuffer.size;
-      screenScale([2 / width, -2 / height, pixRatio, cameraScale]);
+    const progInfo = {
+      background: initBackground(context),
+      circle: initCircle(context),
+      line: initLine(context),
+      fill: initFill(),
+      symbol: initSymbol(context),
+    };
+
+    function compile(info) {
+      const { vert, frag, styleKeys } = info;
+      const program = context.initProgram(preamble + vert, frag);
+      const { use, constructVao, uniformSetters } = program;
+      const load = initLoader(context, info, constructVao, extraAttributes);
+      return { load, use, uniformSetters, styleKeys };
     }
 
-    function setCoords({ x, y, z }) {
-      const numTiles = 1 << z;
-      const xw = x - Math.floor(x / numTiles) * numTiles;
-      const extent = 512; // TODO: don't assume this!!
-      mapCoords([xw, y, z, extent]);
-      return numTiles;
-    }
-
-    function setShift(tileset, pixRatio = 1) {
-      const { x, y } = tileset[0];
-      const { translate, scale: rawScale } = tileset;
-      const scale = rawScale * pixRatio;
-      const [dx, dy] = [x, y].map((c, i) => (c + translate[i]) * scale);
-      mapShift([dx, dy, scale]);
-      return { translate, scale };
-    }
-
-    return { use, setScreen, setCoords, setShift };
+    return Object.entries(progInfo)
+      .reduce((d, [k, info]) => (d[k] = compile(info), d), {});
   }
 
   function camelCase(hyphenated) {
     return hyphenated.replace(/-([a-z])/gi, (h, c) => c.toUpperCase());
   }
 
-  function initStyleProg(style, styleKeys, uniformSetters, spriteTexture) {
-    // TODO: check if spriteTexture is a WebGLTexture
-    const { id, type, paint } = style;
-    const { sdf, sprite } = uniformSetters;
-    const haveSprite = sprite && (spriteTexture instanceof WebGLTexture);
+  function initStyleProg(style, program, context, framebuffer) {
+    if (!program) return;
+
+    const { id, type, layout, paint } = style;
+    const { load, use, uniformSetters, styleKeys } = program;
+    const { sdf, screenScale } = uniformSetters;
+
+    if (type === "line") {
+      // We handle line-miter-limit in the paint phase, not layout phase
+      paint["line-miter-limit"] = layout["line-miter-limit"];
+    }
 
     const zoomFuncs = styleKeys
       .filter(styleKey => paint[styleKey].type !== "property")
@@ -1638,87 +1647,124 @@ void main() {
         return (z, f) => set(get(z, f));
       });
 
-    function setStyles(zoom) {
+    function setStyles(zoom, pixRatio = 1.0, cameraScale = 1.0) {
+      use();
       zoomFuncs.forEach(f => f(zoom));
-      if (haveSprite) sprite(spriteTexture);
+      if (!screenScale) return;
+      const { width, height } = framebuffer.size;
+      screenScale([2 / width, -2 / height, pixRatio, cameraScale]);
     }
 
-    const getData = (type !== "symbol") ? getFeatures :
-      (haveSprite) ? getIcons : getText;
+    const getData = (type === "background") ? initBackgroundData() : getFeatures;
+
+    function draw(tile) {
+      const data = getData(tile);
+      if (data) context.draw(data.buffers);
+    }
+
+    function initBackgroundData() {
+      const buffers = load({});
+      return () => ({ buffers });
+    }
 
     function getFeatures(tile) {
-      return tile.data.layers[id];
-    }
-
-    function getIcons(tile) {
-      const layer = tile.data.layers[id];
-      if (!layer) return;
-      const { type, extent, buffers: { sprite } } = layer;
-      if (sprite) return { type, extent, buffers: sprite };
-    }
-
-    function getText(tile) {
       const { layers: { [id]: layer }, atlas } = tile.data;
-      if (!layer || !atlas) return;
-      const { type, extent, buffers: { text } } = layer;
-      if (!text || !sdf) return;
-      sdf(atlas);
-      return { type, extent, buffers: text };
+      if (sdf && atlas) sdf(atlas);
+      return layer;
     }
 
-    return { setStyles, getData };
+    return { id, type, setStyles, getData, uniformSetters, paint: draw };
   }
 
-  function initTilePainter(context, program, layer, multiTile) {
-    return (multiTile) ? drawTileset : drawTile;
+  function initGL$1(userParams) {
+    const params = setParams$2(userParams);
+    const { context, framebuffer } = params;
+    const programs = compilePrograms(params);
 
-    function drawTile({ tile, zoom, pixRatio = 1.0, cameraScale = 1.0 }) {
-      program.use();
+    return { prep, loadAtlas, loadBuffers, loadSprite, initPainter };
 
-      const data = layer.getData(tile);
-      if (!data) return;
-      const z = (zoom !== undefined) ? zoom : tile.z;
-      layer.setStyles(z);
-
-      program.setScreen(pixRatio, cameraScale);
-      program.setCoords(tile);
-
-      const fakeTileset = [{ x: 0, y: 0 }];
-      Object.assign(fakeTileset, { translate: [0, 0], scale: 512 });
-      program.setShift(fakeTileset, pixRatio);
-
-      context.draw(data.buffers);
+    function prep() {
+      context.bindFramebufferAndSetViewport(framebuffer);
+      return context.clear();
     }
 
-    function drawTileset({ tileset, zoom, pixRatio = 1.0, cameraScale = 1.0 }) {
+    function loadAtlas(atlas) { // TODO: name like loadSprite, different behavior
+      const format = context.gl.ALPHA;
+      const { width, height, data } = atlas;
+      return context.initTexture({ format, width, height, data, mips: false });
+    }
+
+    function loadBuffers(layer) {
+      const program = programs[layer.type];
+      if (!program) throw Error("tile-gl loadBuffers: unknown layer type");
+      layer.buffers = program.load(layer.buffers);
+    }
+
+    function loadSprite(image) {
+      if (!image) return false;
+      const spriteTex = context.initTexture({ image, mips: false });
+      programs.symbol.use();
+      programs.symbol.uniformSetters.sprite(spriteTex);
+      return true;
+    }
+
+    function initPainter(style) {
+      return initStyleProg(style, programs[style.type], context, framebuffer);
+    }
+  }
+
+  function antiMeridianSplit(tileset) {
+    // At low zooms, some tiles may be repeated on opposite ends of the map
+    // We split them into subsets, one tileset for each copy of the map
+
+    const { 0: { x, z }, translate, scale } = tileset;
+    const numTiles = 1 << z;
+
+    function inRange(tile, shift) {
+      const delta = tile.x - x - shift;
+      return (0 <= delta && delta < numTiles);
+    }
+
+    return [0, 1, 2]
+      .map(repeat => repeat * numTiles)
+      .map(shift => tileset.filter(tile => inRange(tile, shift)))
+      .map(tiles => Object.assign(tiles, { translate, scale }))
+      .filter(subset => subset.length);
+  }
+
+  function initTilesetPainter(layer, context, fbSize) {
+    const { mapCoords, mapShift } = layer.uniformSetters;
+
+    return (layer.type === "background") ? paintBackground : paintTileset;
+
+    function paintBackground({ zoom, pixRatio = 1.0, cameraScale = 1.0 }) {
+      layer.setStyles(zoom, pixRatio, cameraScale);
+      layer.paint();
+    }
+
+    function paintTileset({ tileset, zoom, pixRatio = 1.0, cameraScale = 1.0 }) {
       if (!tileset || !tileset.length) return;
+      layer.setStyles(zoom, pixRatio, cameraScale);
 
-      program.use();
-      program.setScreen(pixRatio, cameraScale);
-      layer.setStyles(zoom);
+      // Set mapCoords
+      const { x, y, z } = tileset[0];
+      const numTiles = 1 << z;
+      const xw = x - Math.floor(x / numTiles) * numTiles;
+      const extent = 512; // TODO: don't assume this!!
+      mapCoords([xw, y, z, extent]);
 
-      const numTiles = program.setCoords(tileset[0]);
-      const subsets = antiMeridianSplit(tileset, numTiles);
-
-      subsets.forEach(subset => {
-        const { translate, scale } = program.setShift(subset, pixRatio);
-        subset.forEach(t => drawTileBox(t, translate, scale));
-      });
+      // Draw tiles. Split into subsets if they are repeated across antimeridian
+      antiMeridianSplit(tileset).forEach(subset => drawSubset(subset, pixRatio));
     }
 
-    function antiMeridianSplit(tileset, numTiles) {
-      const { translate, scale } = tileset;
-      const { x } = tileset[0];
+    function drawSubset(tileset, pixRatio = 1) {
+      const { 0: { x, y }, translate, scale: rawScale } = tileset;
+      const scale = rawScale * pixRatio;
 
-      // At low zooms, some tiles may be repeated on opposite ends of the map
-      // We split them into subsets, one tileset for each copy of the map
-      return [0, 1, 2].map(repeat => repeat * numTiles).map(shift => {
-        const tiles = tileset.filter(tile => {
-          const delta = tile.x - x - shift;
-          return (delta >= 0 && delta < numTiles);
-        });
-        return Object.assign(tiles, { translate, scale });
-      }).filter(subset => subset.length);
+      const [dx, dy] = [x, y].map((c, i) => (c + translate[i]) * scale);
+      mapShift([dx, dy, scale]);
+
+      tileset.forEach(tile => drawTileBox(tile, translate, scale));
     }
 
     function drawTileBox(box, translate, scale) {
@@ -1727,214 +1773,61 @@ void main() {
       if (!data) return;
 
       const [x0, y0] = [x, y].map((c, i) => (c + translate[i]) * scale);
-      context.clipRectFlipY(x0, y0, scale, scale);
+      clipRect(x0, y0, scale, scale);
 
       context.draw(data.buffers);
     }
-  }
 
-  function initPrograms(context, framebuffer, preamble, multiTile) {
-    return {
-      "circle": setupProgram(initCircle(context)),
-      "line": setupProgram(initLine(context)),
-      "fill": setupProgram(initFill()),
-      "symbol": setupSymbol(),
-    };
-
-    function setupSymbol() {
-      const spriteProg = setupProgram(initSprite(context));
-      const textProg = setupProgram(initText(context));
-
-      function load(buffers) {
-        const loaded = {};
-        if (buffers.spritePos) loaded.sprite = spriteProg.load(buffers);
-        if (buffers.charPos) loaded.text = textProg.load(buffers);
-        return loaded;
-      }
-
-      function initPainter(style, sprite) {
-        const iconPaint = spriteProg.initPainter(style, sprite);
-        const textPaint = textProg.initPainter(style);
-
-        return function(params) {
-          iconPaint(params);
-          textPaint(params);
-        };
-      }
-
-      return { load, initPainter };
-    }
-
-    function setupProgram(progInfo) {
-      const { vert, frag, styleKeys } = progInfo;
-
-      const program = context.initProgram(preamble + vert, frag);
-      const { use, uniformSetters, constructVao } = program;
-
-      const load = initLoader(context, progInfo, constructVao);
-      const grid = initGrid(use, uniformSetters, framebuffer);
-
-      function initPainter(style, sprite) {
-        const styleProg = initStyleProg(style, styleKeys, uniformSetters, sprite);
-        return initTilePainter(context, grid, styleProg, multiTile);
-      }
-
-      return { load, initPainter };
+    function clipRect(x, y, w, h) {
+      const yflip = fbSize.height - y - h;
+      context.clipRect(x, yflip, w, h);
     }
   }
 
-  function initBackground(context) {
-    function initPainter({ paint }) {
-      return function({ zoom }) {
-        const opacity = paint["background-opacity"](zoom);
-        const color = paint["background-color"](zoom);
-        context.clear(color.map(c => c * opacity));
-      };
-    }
-
-    return { initPainter };
-  }
-
-  function initGLpaint(userParams) {
-    const { context, framebuffer, preamble, multiTile } = setParams$2(userParams);
-
-    const programs = initPrograms(context, framebuffer, preamble, multiTile);
-    programs["background"] = initBackground(context);
-
-    function prep() {
-      context.bindFramebufferAndSetViewport(framebuffer);
-      return context.clear();
-    }
-
-    function loadBuffers(layer) {
-      const { type, buffers } = layer;
-
-      const program = programs[type];
-      if (!program) throw "loadBuffers: unknown layer type";
-
-      layer.buffers = program.load(buffers);
-    }
-
-    function loadAtlas(atlas) {
-      const format = context.gl.ALPHA;
-      const { width, height, data } = atlas;
-      return context.initTexture({ format, width, height, data, mips: false });
-    }
-
-    function loadSprite(image) {
-      if (image) return context.initTexture({ image, mips: false });
-    }
-
-    function initPainter(style, sprite) {
-      const { id, type, source, minzoom = 0, maxzoom = 24 } = style;
-
-      const program = programs[type];
-      if (!program) return () => null;
-
-      const { layout, paint } = style;
-      if (type === "line") {
-        // We handle line-miter-limit in the paint phase, not layout phase
-        paint["line-miter-limit"] = layout["line-miter-limit"];
-      }
-      const painter = program.initPainter(style, sprite);
-      return Object.assign(painter, { id, type, source, minzoom, maxzoom });
-    }
-
-    return { prep, loadBuffers, loadAtlas, loadSprite, initPainter };
-  }
-
-  function setParams$1(userParams) {
-    const gl = userParams.context.gl;
-    if (!(gl instanceof WebGL2RenderingContext)) fail$1("no valid WebGL context");
-
+  function initGL(userParams) {
     const {
-      context,
-      framebuffer = { buffer: null, size: gl.canvas },
-      center = [0.0, 0.0], // ASSUMED to be in degrees!
-      zoom = 4,
-      style,
-      mapboxToken,
-      clampY = true,
-      units = "degrees",
+      context, framebuffer,
       projScale = false,
     } = userParams;
 
-    const { buffer, size } = framebuffer;
-    if (!(buffer instanceof WebGLFramebuffer) && buffer !== null) {
-      fail$1("no valid framebuffer");
-    }
+    const scaleCode = (projScale) ? mercatorScale : simpleScale;
 
-    const sizeType =
-      (size && allPosInts(size.clientWidth, size.clientHeight)) ? "client" :
-      (size && allPosInts(size.width, size.height)) ? "raw" :
-      null;
-    if (!sizeType) fail$1("invalid size object in framebuffer");
-    const getViewport = (sizeType === "client")
-      ? () => ([size.clientWidth, size.clientHeight])
-      : () => ([size.width, size.height]);
-
-    const validUnits = ["degrees", "radians", "xy"];
-    if (!validUnits.includes(units)) fail$1("invalid units");
-    const projection = getProjection(units);
-
-    // Convert initial center position from degrees to the specified units
-    if (!checkCoords$1(center, 2)) fail$1("invalid center coordinates");
-    const projCenter = getProjection("degrees").forward(center);
-    if (!all0to1(...projCenter)) fail$1 ("invalid center coordinates");
-    const invCenter = projection.inverse(projCenter);
-
-    if (!Number.isFinite(zoom)) fail$1("invalid zoom value");
-
-    const coords = initCoords({
-      getViewport, projection,
-      center: invCenter,
-      zoom, clampY,
+    const tileContext = initGL$1({
+      context, framebuffer,
+      preamble: preamble + scaleCode,
+      extraAttributes: { tileCoords: { numComponents: 3 } },
     });
 
-    return {
-      gl, framebuffer,
-      projection, coords,
-      style, mapboxToken,
-      context: initGLpaint({ context, framebuffer, projScale }),
+    // Replace initPainter method with a multi-tile program
+    const initPainter = tileContext.initPainter;
+    tileContext.initPainter = function(style) {
+      const layer = initPainter(style);
+      const painter = (layer)
+        ? initTilesetPainter(layer, context, framebuffer.size)
+        : () => null;
+      const { id, type, source, minzoom = 0, maxzoom = 24 } = style;
+      return Object.assign(painter, { id, type, source, minzoom, maxzoom });
     };
-  }
 
-  function fail$1(message) {
-    throw Error("tile-setter parameter check: " + message + "!");
-  }
-
-  function allPosInts(...vals) {
-    return vals.every(v => Number.isInteger(v) && v > 0);
-  }
-
-  function all0to1(...vals) {
-    return vals.every(v => Number.isFinite(v) && v >= 0 && v <= 1);
-  }
-
-  function checkCoords$1(p, n) {
-    const isArray = Array.isArray(p) ||
-      (ArrayBuffer.isView(p) && !(p instanceof DataView));
-    return isArray && p.length >= n &&
-      p.slice(0, n).every(Number.isFinite);
+    return tileContext;
   }
 
   function expandStyleURL(url, token) {
     const prefix = /^mapbox:\/\/styles\//;
-    if ( !url.match(prefix) ) return url;
+    if (!url.match(prefix)) return url;
     const apiRoot = "https://api.mapbox.com/styles/v1/";
     return url.replace(prefix, apiRoot) + "?access_token=" + token;
   }
 
   function expandSpriteURLs(url, pixRatio, token) {
     // Returns an array containing urls to .png and .json files
-    const { min, max, floor } = Math;
-    const ratio = floor(min(max(1.0, pixRatio), 4.0));
+    const ratio = Math.floor(Math.min(Math.max(1.0, pixRatio), 4.0));
     const ratioStr = (ratio > 1)
       ? "@" + ratio + "x"
       : "";
 
     const prefix = /^mapbox:\/\/sprites\//;
-    if ( !url.match(prefix) ) return {
+    if (!url.match(prefix)) return {
       image: url + ratioStr + ".png",
       meta: url + ratioStr + ".json",
     };
@@ -1951,14 +1844,14 @@ void main() {
 
   function expandTileURL(url, token) {
     const prefix = /^mapbox:\/\//;
-    if ( !url.match(prefix) ) return url;
+    if (!url.match(prefix)) return url;
     const apiRoot = "https://api.mapbox.com/v4/";
     return url.replace(prefix, apiRoot) + ".json?secure&access_token=" + token;
   }
 
   function expandGlyphURL(url, token) {
     const prefix = /^mapbox:\/\/fonts\//;
-    if ( !url.match(prefix) ) return url;
+    if (!url.match(prefix)) return url;
     const apiRoot = "https://api.mapbox.com/fonts/v1/";
     return url.replace(prefix, apiRoot) + "?access_token=" + token;
   }
@@ -2005,6 +1898,12 @@ void main() {
       img.crossOrigin = "anonymous";
       img.src = href;
     });
+  }
+
+  function warn(message) {
+    console.log("tile-stencil had a problem loading part of the style document");
+    console.log("  " + message);
+    console.log("  Not a fatal error. Proceeding with the rest of the style...");
   }
 
   function define(constructor, factory, prototype) {
@@ -2681,54 +2580,24 @@ void main() {
     },
   };
 
-  const refProperties = [
-    "type",
-    "source",
-    "source-layer",
-    "minzoom",
-    "maxzoom",
-    "filter",
-    "layout"
-  ];
+  const refProperties = ["type", "minzoom", "maxzoom",
+    "source", "source-layer", "filter", "layout"];
 
   function derefLayers(layers) {
-    // From mapbox-gl-js, style-spec/deref.js
-    /**
-     * Given an array of layers, some of which may contain `ref` properties
-     * whose value is the `id` of another property, return a new array where
-     * such layers have been augmented with the 'type', 'source', etc. properties
-     * from the parent layer, and the `ref` property has been removed.
-     *
-     * The input is not modified. The output may contain references to portions
-     * of the input.
-     */
-    layers = layers.slice(); // ??? What are we trying to achieve here?
+    // Some layers in Mapbox styles contain a non-standard "ref" property,
+    // pointing to the "id" of another layer.
+    // Augment these layers with properties from the referenced layer
 
-    const map = Object.create(null); // stackoverflow.com/a/21079232/10082269
-    layers.forEach( layer => { map[layer.id] = layer; } );
-
-    for (let i = 0; i < layers.length; i++) {
-      if ("ref" in layers[i]) {
-        layers[i] = deref(layers[i], map[layers[i].ref]);
-      }
-    }
-
-    return layers;
+    const map = layers.reduce((m, l) => (m[l.id] = l, m), {});
+    return layers.map(l => ("ref" in l) ? deref(l, map[l.ref]) : l);
   }
 
   function deref(layer, parent) {
-    const result = {};
+    const result = Object.assign({}, layer);
+    delete result.ref;
 
-    for (const k in layer) {
-      if (k !== "ref") {
-        result[k] = layer[k];
-      }
-    }
-
-    refProperties.forEach((k) => {
-      if (k in parent) {
-        result[k] = parent[k];
-      }
+    refProperties.forEach(k => {
+      if (k in parent) result[k] = parent[k];
     });
 
     return result;
@@ -2761,47 +2630,28 @@ void main() {
         (url) ? getJSON(expandTileURL(url, token)) : // Get linked TileJSON
         Promise.resolve({}); // No linked info
 
-      return infoPromise.then(info => {
-        // Assign everything to a new object for return.
-        // Note: shallow copy! Some properties may point back to the original
-        // style document, like .vector_layers, .bounds, .center, .extent
-        const updatedSource = Object.assign({}, source, info, { type });
-        return { [key]: updatedSource };
-      });
+      return infoPromise.then(
+        val => ({ [key]: Object.assign({}, source, val, { type }) }),
+        err => (warn("sources." + key + ": " + err.message), ({}))
+      );
     }
 
-    return Promise.allSettled(expandPromises)
-      .then(results => results.reduce(processResult, {}));
-
-    function processResult(sources, result) {
-      if (result.status === "fulfilled") {
-        return Object.assign(sources, result.value);
-      } else {
-        // If one source fails to load, just log the reason and move on
-        warn("Error loading sources: " + result.reason.message);
-        return sources;
-      }
-    }
+    return Promise.all(expandPromises).then(results => {
+      return results.reduce((a, c) => Object.assign(a, c), {});
+    });
   }
 
   function loadSprite(sprite, token) {
     if (!sprite) return;
 
-    const pixRatio = window?.devicePixelRatio || 1.0;
+    const notWorker = (window && window.devicePixelRatio);
+    const pixRatio = (notWorker) ? window.devicePixelRatio : 1.0;
     const urls = expandSpriteURLs(sprite, pixRatio, token);
 
-    return Promise.all([getImage(urls.image), getJSON(urls.meta)])
-      .then( ([image, meta]) => ({ image, meta }) )
-      .catch(err => {
-        // If sprite doesn't load, just log the error and move on
-        warn("Error loading sprite: " + err.message);
-      });
-  }
-
-  function warn(message) {
-    console.log("tile-stencil had a problem loading part of the style document");
-    console.log("  " + message);
-    console.log("  Not a fatal error. Proceeding with the rest of the style...");
+    return Promise.all([getImage(urls.image), getJSON(urls.meta)]).then(
+      ([image, meta]) => ({ image, meta }),
+      err => warn("sprite: " + err.message)
+    );
   }
 
   function getStyleFuncs(inputLayer) {
@@ -2840,6 +2690,81 @@ void main() {
       null;
 
     return (error) ? Promise.reject(error) : doc;
+  }
+
+  function setParams$1(userParams) {
+    const gl = userParams.context.gl;
+    if (!(gl instanceof WebGL2RenderingContext)) fail$1("no valid WebGL context");
+
+    const {
+      context,
+      framebuffer = { buffer: null, size: gl.canvas },
+      center = [0.0, 0.0], // ASSUMED to be in degrees!
+      zoom = 4,
+      style,
+      mapboxToken,
+      clampY = true,
+      units = "degrees",
+      projScale = false,
+    } = userParams;
+
+    const { buffer, size } = framebuffer;
+    if (!(buffer instanceof WebGLFramebuffer) && buffer !== null) {
+      fail$1("no valid framebuffer");
+    }
+
+    const sizeType =
+      (size && allPosInts(size.clientWidth, size.clientHeight)) ? "client" :
+      (size && allPosInts(size.width, size.height)) ? "raw" :
+      null;
+    if (!sizeType) fail$1("invalid size object in framebuffer");
+    const getViewport = (sizeType === "client")
+      ? () => ([size.clientWidth, size.clientHeight])
+      : () => ([size.width, size.height]);
+
+    const validUnits = ["degrees", "radians", "xy"];
+    if (!validUnits.includes(units)) fail$1("invalid units");
+    const projection = getProjection(units);
+
+    // Convert initial center position from degrees to the specified units
+    if (!checkCoords$1(center, 2)) fail$1("invalid center coordinates");
+    const projCenter = getProjection("degrees").forward(center);
+    if (!all0to1(...projCenter)) fail$1 ("invalid center coordinates");
+    const invCenter = projection.inverse(projCenter);
+
+    if (!Number.isFinite(zoom)) fail$1("invalid zoom value");
+
+    const coords = initCoords({
+      getViewport, projection,
+      center: invCenter,
+      zoom, clampY,
+    });
+
+    return {
+      gl, framebuffer,
+      projection, coords,
+      style, mapboxToken,
+      context: initGL({ context, framebuffer, projScale }),
+    };
+  }
+
+  function fail$1(message) {
+    throw Error("tile-setter parameter check: " + message + "!");
+  }
+
+  function allPosInts(...vals) {
+    return vals.every(v => Number.isInteger(v) && v > 0);
+  }
+
+  function all0to1(...vals) {
+    return vals.every(v => Number.isFinite(v) && v >= 0 && v <= 1);
+  }
+
+  function checkCoords$1(p, n) {
+    const isArray = Array.isArray(p) ||
+      (ArrayBuffer.isView(p) && !(p instanceof DataView));
+    return isArray && p.length >= n &&
+      p.slice(0, n).every(Number.isFinite);
   }
 
   initZeroTimeouts$1();
@@ -3043,13 +2968,13 @@ void main() {
       source, glyphs, layers, spriteData,
     } = userParams;
 
-    if (source?.type === "vector") {
+    if (source && source.type === "vector") {
       if (!source.tiles.length) fail$2("no valid vector tile endpoint");
-    } else if (source?.type !== "geojson") {
+    } else if (source && source.type !== "geojson") {
       fail$2("no valid vector or geojson source");
     }
 
-    if (!layers?.length) fail$2 ("no valid array of style layers");
+    if (!layers || !layers.length) fail$2 ("no valid array of style layers");
     if (!layers.every(isVector)) fail$2("not all layers are vector layers");
 
     const sameSource = layers.every(l => l.source === layers[0].source);
@@ -6469,28 +6394,26 @@ function updateFonts(fonts, feature) {
   return fonts;
 }
 
-function initStyleGetters(keys, { layout, paint }) {
-  const layoutFuncs = keys.layout
-    .map(k => ([camelCase$1(k), layout[k]]));
+function initStyleGetters(keys, { layout }) {
+  const styleFuncs = keys.map(k => ([layout[k], camelCase$1(k)]));
 
-  const bufferFuncs = keys.paint
-    .filter(k => paint[k].type === "property")
-    .map(k => ([camelCase$1(k), paint[k]]));
-
-  return function(zoom, feature) {
-    const layoutVals = layoutFuncs
-      .reduce((d, [k, f]) => (d[k] = f(zoom, feature), d), {});
-
-    const bufferVals = bufferFuncs
-      .reduce((d, [k, f]) => (d[k] = f(zoom, feature), d), {});
-
-    return { layoutVals, bufferVals };
+  return function(z, feature) {
+    return styleFuncs.reduce((d, [g, k]) => (d[k] = g(z, feature), d), {});
   };
 }
 
 function camelCase$1(hyphenated) {
   return hyphenated.replace(/-([a-z])/gi, (h, c) => c.toUpperCase());
 }
+
+const styleKeys = [
+  "icon-opacity",
+  "text-color",
+  "text-opacity",
+  "text-halo-blur",
+  "text-halo-color",
+  "text-halo-width",
+];
 
 function getBox(w, h, anchor, offset) {
   const [sx, sy] = getBoxShift(anchor);
@@ -6551,15 +6474,13 @@ function initIcon(style, spriteData = {}) {
   const { image: { width, height } = {}, meta = {} } = spriteData;
   if (!width || !height) return () => undefined;
 
-  const getStyles = initStyleGetters(iconKeys, style);
+  const getStyles = initStyleGetters(iconLayoutKeys, style);
 
   return function(feature, tileCoords) {
     const sprite = getSprite(feature.spriteID);
     if (!sprite) return;
 
-    const { layoutVals, bufferVals } = getStyles(tileCoords.z, feature);
-    const icon = layoutSprite(sprite, layoutVals);
-    return Object.assign(icon, { bufferVals }); // TODO: rethink this
+    return layoutSprites(sprite, getStyles(tileCoords.z, feature));
   };
 
   function getSprite(spriteID) {
@@ -6575,21 +6496,16 @@ function initIcon(style, spriteData = {}) {
   }
 }
 
-const iconKeys = {
-  layout: [
-    "icon-anchor",
-    "icon-offset",
-    "icon-padding",
-    "icon-rotation-alignment",
-    "icon-size",
-  ],
-  paint: [
-    "icon-opacity",
-  ],
-};
+const iconLayoutKeys = [
+  "icon-anchor",
+  "icon-offset",
+  "icon-padding",
+  "icon-rotation-alignment",
+  "icon-size",
+];
 
-function layoutSprite(sprite, styleVals) {
-  const { metrics: { w, h }, spriteRect } = sprite;
+function layoutSprites(sprite, styleVals) {
+  const { metrics: { w, h }, spriteRect: rect } = sprite;
 
   const { iconAnchor, iconOffset, iconSize, iconPadding } = styleVals;
   const iconbox = getBox(w, h, iconAnchor, iconOffset);
@@ -6597,7 +6513,8 @@ function layoutSprite(sprite, styleVals) {
 
   const pos = [iconbox.x, iconbox.y, w, h].map(c => c * iconSize);
 
-  return { pos, rect: spriteRect, bbox };
+  // Structure return value to match ../text
+  return Object.assign([{ pos, rect }], { bbox, fontScalar: 0.0 });
 }
 
 const whitespace = {
@@ -6834,43 +6751,33 @@ function layout(glyphs, styleVals) {
 }
 
 function initText(style) {
-  const getStyles = initStyleGetters(textKeys, style);
+  const getStyles = initStyleGetters(textLayoutKeys, style);
 
   return function(feature, tileCoords, atlas) {
     const glyphs = getGlyphs(feature, atlas);
     if (!glyphs || !glyphs.length) return;
 
-    const { layoutVals, bufferVals } = getStyles(tileCoords.z, feature);
-    const chars = layout(glyphs, layoutVals);
-    return Object.assign(chars, { bufferVals }); // TODO: rethink this
+    return layout(glyphs, getStyles(tileCoords.z, feature));
   };
 }
 
-const textKeys = {
-  layout: [
-    "symbol-placement", // TODO: both here and in ../anchors/anchors.js
-    "text-anchor",
-    "text-justify",
-    "text-letter-spacing",
-    "text-line-height",
-    "text-max-width",
-    "text-offset",
-    "text-padding",
-    "text-rotation-alignment",
-    "text-size",
-  ],
-  paint: [
-    "text-color",
-    "text-opacity",
-    "text-halo-blur",
-    "text-halo-color",
-    "text-halo-width",
-  ],
-};
+const textLayoutKeys = [
+  "symbol-placement", // TODO: both here and in ../anchors/anchors.js
+  "text-anchor",
+  "text-justify",
+  "text-letter-spacing",
+  "text-line-height",
+  "text-max-width",
+  "text-offset",
+  "text-padding",
+  "text-rotation-alignment",
+  "text-size",
+];
 
 function getGlyphs(feature, atlas) {
+  if (!atlas) return;
   const { charCodes, font } = feature;
-  const positions = atlas?.positions[font];
+  const positions = atlas.positions[font];
   if (!positions || !charCodes || !charCodes.length) return;
 
   const { width, height } = atlas.image;
@@ -6897,9 +6804,9 @@ function buildCollider(placement) {
 
 function pointCollision(icon, text, anchor, tree) {
   const [x0, y0] = anchor;
-  const boxes = [];
-  if (icon) boxes.push(formatBox(x0, y0, icon.bbox));
-  if (text) boxes.push(formatBox(x0, y0, text.bbox));
+  const boxes = [icon, text]
+    .filter(label => label !== undefined)
+    .map(label => formatBox(x0, y0, label.bbox));
 
   if (boxes.some(tree.collides, tree)) return true;
   // TODO: drop if outside tile?
@@ -6922,17 +6829,16 @@ function lineCollision(icon, text, anchor, tree) {
   const sin_a = sin$1(angle);
   const rotate = ([x, y]) => [x * cos_a - y * sin_a, x * sin_a + y * cos_a];
 
-  const boxes = [];
-  if (text) text.map(c => getCharBbox(c.pos, rotate))
-    .map(bbox => formatBox(x0, y0, bbox))
-    .forEach(box => boxes.push(box));
-  if (icon) boxes.push(formatBox(x0, y0, getCharBbox(icon.pos, rotate)));
+  const boxes = [icon, text].flat()
+    .filter(glyph => glyph !== undefined)
+    .map(g => getGlyphBbox(g.pos, rotate))
+    .map(bbox => formatBox(x0, y0, bbox));
 
   if (boxes.some(tree.collides, tree)) return true;
   boxes.forEach(tree.insert, tree);
 }
 
-function getCharBbox([x, y, w, h], rotate) {
+function getGlyphBbox([x, y, w, h], rotate) {
   const corners = [
     [x, y], [x + w, y],
     [x, y + h], [x + w, y + h]
@@ -7144,7 +7050,9 @@ function getLineAnchors(geometry, extent, icon, text, layoutVals) {
   const alignment = (text) ? textRotationAlignment : iconRotationAlignment;
   const keepUpright = (text) ? textKeepUpright : iconKeepUpright;
 
-  const box = mergeBoxes(icon?.bbox, text?.bbox);
+  const iconbox = (icon) ? icon.bbox : undefined;
+  const textbox = (text) ? text.bbox : undefined;
+  const box = mergeBoxes(iconbox, textbox);
   const labelLength = (alignment === "viewport") ? 0.0 : box[2] - box[0];
   const spacing = max(symbolSpacing, labelLength + symbolSpacing / 4);
 
@@ -7180,10 +7088,10 @@ function getLineAnchors(geometry, extent, icon, text, layoutVals) {
 }
 
 function initAnchors(style) {
-  const getStyles = initStyleGetters(symbolKeys, style);
+  const getStyles = initStyleGetters(symbolLayoutKeys, style);
 
   return function(feature, tileCoords, icon, text, tree) {
-    const { layoutVals } = getStyles(tileCoords.z, feature);
+    const layoutVals = getStyles(tileCoords.z, feature);
     const collides = buildCollider(layoutVals.symbolPlacement);
 
     // TODO: get extent from tile?
@@ -7192,19 +7100,16 @@ function initAnchors(style) {
   };
 }
 
-const symbolKeys = {
-  layout: [
-    "symbol-placement",
-    "symbol-spacing",
-    // TODO: these are in 2 places: here and in the text getter
-    "text-rotation-alignment",
-    "text-size",
-    "icon-rotation-alignment",
-    "icon-keep-upright",
-    "text-keep-upright",
-  ],
-  paint: [],
-};
+const symbolLayoutKeys = [
+  "symbol-placement",
+  "symbol-spacing",
+  // TODO: these are in 2 places: here and in the text getter
+  "text-rotation-alignment",
+  "text-size",
+  "icon-rotation-alignment",
+  "icon-keep-upright",
+  "text-keep-upright",
+];
 
 function getAnchors(geometry, extent, icon, text, layoutVals) {
   switch (layoutVals.symbolPlacement) {
@@ -7228,54 +7133,22 @@ function getPointAnchors({ type, coordinates }) {
   }
 }
 
-function getBuffers(icon, text, anchor, tileCoords) {
-  const iconBuffers = getIconBuffers(icon, anchor, tileCoords);
-  const textBuffers = getTextBuffers(text, anchor, tileCoords);
-  return mergeBuffers(iconBuffers, textBuffers);
+function getBuffers(icon, text, anchor) {
+  const iconBuffers = buildBuffers(icon, anchor);
+  const textBuffers = buildBuffers(text, anchor);
+  return [iconBuffers, textBuffers].filter(b => b !== undefined);
 }
 
-function getIconBuffers(icon, anchor, { z, x, y }) {
-  if (!icon) return;
+function buildBuffers(glyphs, anchor) {
+  if (!glyphs) return;
 
-  // NOTE: mergeBuffers may overwrite tileCoords with the text buffer of the
-  // same name. This is OK because the text buffer, if it exists, is longer
-  const buffers = {
-    spriteRect: icon.rect,
-    spritePos: icon.pos,
-    labelPos0: [...anchor],
-    tileCoords: [x, y, z],
+  const origin = [...anchor, glyphs.fontScalar];
+
+  return {
+    glyphRect: glyphs.flatMap(g => g.rect),
+    glyphPos: glyphs.flatMap(g => g.pos),
+    labelPos: glyphs.flatMap(() => origin),
   };
-
-  Object.entries(icon.bufferVals).forEach(([key, val]) => {
-    buffers[key] = val;
-  });
-
-  return buffers;
-}
-
-function getTextBuffers(text, anchor, { z, x, y }) {
-  if (!text) return;
-
-  const origin = [...anchor, text.fontScalar];
-
-  const buffers = {
-    sdfRect: text.flatMap(c => c.rect),
-    charPos: text.flatMap(c => c.pos),
-    labelPos: text.flatMap(() => origin),
-    tileCoords: text.flatMap(() => [x, y, z]),
-  };
-
-  Object.entries(text.bufferVals).forEach(([key, val]) => {
-    buffers[key] = text.flatMap(() => val);
-  });
-
-  return buffers;
-}
-
-function mergeBuffers(buf1, buf2) {
-  if (!buf1) return buf2;
-  if (!buf2) return buf1;
-  return Object.assign(buf1, buf2);
 }
 
 function initShaping(style, spriteData) {
@@ -7283,7 +7156,9 @@ function initShaping(style, spriteData) {
   const getText = initText(style);
   const getAnchors = initAnchors(style);
 
-  return function(feature, tileCoords, atlas, tree) {
+  return { serialize, getLength, styleKeys };
+
+  function serialize(feature, tileCoords, atlas, tree) {
     // tree is an RBush from the 'rbush' module. NOTE: will be updated!
 
     const icon = getIcon(feature, tileCoords);
@@ -7294,9 +7169,13 @@ function initShaping(style, spriteData) {
     if (!anchors || !anchors.length) return;
 
     return anchors
-      .map(anchor => getBuffers(icon, text, anchor, tileCoords))
+      .flatMap(anchor => getBuffers(icon, text, anchor))
       .reduce(combineBuffers, {});
-  };
+  }
+
+  function getLength(buffers) {
+    return buffers.labelPos.length / 4;
+  }
 }
 
 function combineBuffers(dict, buffers) {
@@ -7307,14 +7186,32 @@ function combineBuffers(dict, buffers) {
   return dict;
 }
 
+function setParams(userParams) {
+  const { glyphs, spriteData, layers } = userParams;
+
+  if (!layers || !layers.length) fail("no valid array of style layers");
+  const parsedStyles = layers.map(getStyleFuncs);
+
+  const glyphsOK = ["string", "undefined"].includes(typeof glyphs);
+  if (!glyphsOK) fail("glyphs must be a string URL");
+
+  const getAtlas = initAtlasGetter({ parsedStyles, glyphEndpoint: glyphs });
+
+  return { parsedStyles, spriteData, getAtlas };
+}
+
+function fail(message) {
+  throw Error("tile-gl initSerializer: " + message);
+}
+
 const circleInfo = {
   styleKeys: ["circle-radius", "circle-color", "circle-opacity"],
   serialize: flattenPoints,
   getLength: (buffers) => buffers.circlePos.length / 2,
 };
 
-function flattenPoints(geometry) {
-  const { type, coordinates } = geometry;
+function flattenPoints(feature) {
+  const { type, coordinates } = feature.geometry;
   if (!coordinates || !coordinates.length) return;
 
   switch (type) {
@@ -7338,8 +7235,8 @@ const lineInfo = {
   getLength: (buffers) => buffers.lines.length / 3,
 };
 
-function flattenLines(geometry) {
-  const { type, coordinates } = geometry;
+function flattenLines(feature) {
+  const { type, coordinates } = feature.geometry;
   if (!coordinates || !coordinates.length) return;
 
   switch (type) {
@@ -8084,8 +7981,8 @@ const fillInfo = {
   getLength: (buffers) => buffers.position.length / 2,
 };
 
-function triangulate(geometry) {
-  const { type, coordinates } = geometry;
+function triangulate(feature) {
+  const { type, coordinates } = feature.geometry;
   if (!coordinates || !coordinates.length) return;
 
   switch (type) {
@@ -8113,16 +8010,14 @@ function camelCase(hyphenated) {
   return hyphenated.replace(/-([a-z])/gi, (h, c) => c.toUpperCase());
 }
 
-function initFeatureSerializer(style, spriteData) {
-  const { type, paint } = style;
-
-  switch (type) {
+function getSerializeInfo(style, spriteData) {
+  switch (style.type) {
     case "circle":
-      return initParsing(paint, circleInfo);
+      return circleInfo;
     case "line":
-      return initParsing(paint, lineInfo);
+      return lineInfo;
     case "fill":
-      return initParsing(paint, fillInfo);
+      return fillInfo;
     case "symbol":
       return initShaping(style, spriteData);
     default:
@@ -8130,20 +8025,21 @@ function initFeatureSerializer(style, spriteData) {
   }
 }
 
-function initParsing(paint, info) {
+function initFeatureSerializer(paint, info) {
   const { styleKeys, serialize, getLength } = info;
-  const dataFuncs = styleKeys.filter(k => paint[k].type === "property")
+
+  const dataFuncs = styleKeys
+    .filter(k => paint[k].type === "property")
     .map(k => ([paint[k], camelCase(k)]));
 
-  return function(feature, { z, x, y }) {
-    const buffers = serialize(feature.geometry);
+  return function(feature, tileCoords, atlas, tree) {
+    const buffers = serialize(feature, tileCoords, atlas, tree);
     if (!buffers) return;
 
     const dummy = Array.from({ length: getLength(buffers) });
 
-    buffers.tileCoords = dummy.flatMap(() => [x, y, z]);
     dataFuncs.forEach(([get, key]) => {
-      const val = get(null, feature);
+      const val = get(null, feature); // Note: could be an Array
       buffers[key] = dummy.flatMap(() => val);
     });
 
@@ -8151,17 +8047,18 @@ function initParsing(paint, info) {
   };
 }
 
-function concatBuffers(features) {
+function concatBuffers(buffers) {
   // Concatenate the buffers from all the features
-  const arrays = features.map(f => f.buffers).reduce(appendBuffers, {});
+  const arrays = buffers.reduce(appendBuffers, {});
 
   // Convert to TypedArrays (now that the lengths are finalized)
-  return Object.entries(arrays).reduce((d, [key, buffer]) => {
-    d[key] = (key === "indices")
-      ? new Uint32Array(buffer)
-      : new Float32Array(buffer);
-    return d;
-  }, {});
+  return Object.entries(arrays)
+    .reduce((d, [k, a]) => (d[k] = makeTypedArray(k, a), d), {});
+}
+
+function makeTypedArray(key, array) {
+  const type = (key === "indices") ? Uint32Array : Float32Array;
+  return new type(array);
 }
 
 function appendBuffers(buffers, newBuffers) {
@@ -8184,25 +8081,24 @@ function appendBuffers(buffers, newBuffers) {
 function initLayerSerializer(style, spriteData) {
   const { id, type, interactive } = style;
 
-  const transform = initFeatureSerializer(style, spriteData);
+  const info = getSerializeInfo(style, spriteData);
+  const transform = initFeatureSerializer(style.paint, info);
   if (!transform) return;
 
   return function(layer, tileCoords, atlas, tree) {
     const { extent, features } = layer;
 
-    const transformed = features.map(feature => {
-      const { properties, geometry } = feature;
-      const buffers = transform(feature, tileCoords, atlas, tree);
-      // If no buffers, skip entire feature (it won't be rendered)
-      if (buffers) return { properties, geometry, buffers };
-    }).filter(f => f !== undefined);
+    const transformed = features
+      .map(f => transform(f, tileCoords, atlas, tree))
+      .filter(f => f !== undefined);
 
     if (!transformed.length) return;
 
-    const newLayer = { type, extent, buffers: concatBuffers(transformed) };
+    const buffers = concatBuffers(transformed);
+    const length = info.getLength(buffers);
+    const newLayer = { type, extent, buffers, length };
 
-    if (interactive) newLayer.features = transformed
-      .map(({ properties, geometry }) => ({ properties, geometry }));
+    if (interactive) newLayer.features = features.slice();
 
     return { [id]: newLayer };
   };
@@ -8773,52 +8669,57 @@ function multiSelect(arr, left, right, n, compare) {
     }
 }
 
-function initTileSerializer(styles, spriteData) {
-  const layerSerializers = styles
+function initSerializer$1(userParams) {
+  const { parsedStyles, spriteData, getAtlas } = setParams(userParams);
+
+  const layerSerializers = parsedStyles
     .reduce((d, s) => (d[s.id] = initLayerSerializer(s, spriteData), d), {});
 
-  return function(layers, tileCoords, atlas) {
+  return function(source, tileCoords) {
+    return getAtlas(source, tileCoords.z)
+      .then(atlas => process(source, tileCoords, atlas));
+  };
+
+  function process(source, coords, atlas) {
     const tree = new RBush();
 
-    return Object.entries(layers)
+    function serializeLayer([id, layer]) {
+      const serialize = layerSerializers[id];
+      if (serialize) return serialize(layer, coords, atlas, tree);
+    }
+
+    const layers = Object.entries(source)
       .reverse() // Reverse order for collision checks
-      .map(([id, layer]) => {
-        const serialize = layerSerializers[id];
-        if (serialize) return serialize(layer, tileCoords, atlas, tree);
-      })
+      .map(serializeLayer)
       .reverse()
       .reduce((d, l) => Object.assign(d, l), {});
-  };
+
+    // Note: atlas.data.buffer is a Transferable
+    return { atlas: atlas.image, layers };
+  }
+}
+
+function addTileCoords(tile, coords) {
+  const { z, x, y } = coords;
+
+  Object.values(tile.layers).forEach(layer => {
+    const { length, buffers } = layer;
+    const coordArray = Array.from({ length }).flatMap(() => [x, y, z]);
+    buffers.tileCoords = new Float32Array(coordArray);
+  });
+
+  return tile;
 }
 
 function initSerializer(userParams) {
-  const { glyphEndpoint, spriteData, layers } = setParams(userParams);
-  const parsedStyles = layers.map(getStyleFuncs);
+  const serialize = initSerializer$1(userParams);
 
-  const getAtlas = initAtlasGetter({ parsedStyles, glyphEndpoint });
-  const process = initTileSerializer(parsedStyles, spriteData);
+  function wrapSerialize(source, tileCoords) {
+    return serialize(source, tileCoords)
+      .then(tile => addTileCoords(tile, tileCoords));
+  }
 
-  return function(source, tileCoords) {
-    return getAtlas(source, tileCoords.z).then(atlas => {
-      const layers = process(source, tileCoords, atlas);
-
-      // Note: atlas.data.buffer is a Transferable
-      return { atlas: atlas.image, layers };
-    });
-  };
-}
-
-function setParams({ glyphs, spriteData, layers }) {
-  if (!layers || !layers.length) fail("no valid array of style layers");
-
-  const glyphsOK = ["string", "undefined"].includes(typeof glyphs);
-  if (!glyphsOK) fail("glyphs must be a string URL");
-
-  return { glyphEndpoint: glyphs, spriteData, layers };
-}
-
-function fail(message) {
-  throw Error("tile-gl initSerializer: " + message);
+  return wrapSerialize;
 }
 
 function initTileFunctions({ source, glyphs, spriteData, layers }) {
@@ -9331,13 +9232,11 @@ function sendTile({ id, tile, transferables }) {
     const { PI, cosh } = Math;
     const { layers, spriteData } = style;
 
-    const sprite = context.loadSprite(spriteData?.image);
+    if (spriteData) context.loadSprite(spriteData.image);
 
     const painters = layers.map(layer => {
-      const painter = context.initPainter(getStyleFuncs(layer), sprite);
-
-      painter.visible = () => layer.visible;
-      return painter;
+      const painter = context.initPainter(getStyleFuncs(layer));
+      return Object.assign(painter, { visible: () => layer.visible });
     });
 
     return function(tilesets, pixRatio = 1, dzScale = 1) {
@@ -11007,6 +10906,92 @@ function sendTile({ id, tile, transferables }) {
     }
   }
 
+  function interpolateZoom(p0, p1) {
+    const [ux0, uy0, w0] = p0;
+    const [ux1, uy1, w1] = p1;
+
+    const { cosh, sinh, tanh, exp, log, hypot, SQRT2, abs } = Math;
+    const rho = SQRT2;
+    const epsilon = 1e-6;
+
+    const dx = ux1 - ux0;
+    const dy = uy1 - uy0;
+    const du = hypot(dx, dy);
+
+    const rho2du = rho * rho * du;
+    const uScale = w0 / rho2du;
+
+    const b0 = (w1 * w1 - w0 * w0 + rho2du * rho2du) / (2 * w0 * rho2du);
+    const b1 = (w1 * w1 - w0 * w0 - rho2du * rho2du) / (2 * w1 * rho2du);
+    const r0 = log(hypot(b0, 1) - b0);
+    const r1 = log(hypot(b1, 1) - b1);
+    const coshr0 = cosh(r0);
+    const sinhr0 = sinh(r0);
+
+    const rhoS = (du < epsilon) ? log(w1 / w0) : (r1 - r0);
+
+    function special(t) { // Special case for u0 =~ u1
+      return [
+        ux0 + t * dx,
+        uy0 + t * dy,
+        w0 * exp(rhoS * t),
+      ];
+    }
+
+    function general(t) { // General case
+      const uarg = rhoS * t + r0;
+      const u = uScale * (coshr0 * tanh(uarg) - sinhr0);
+      return [
+        ux0 + u * dx,
+        uy0 + u * dy,
+        w0 * coshr0 / cosh(uarg)
+      ];
+    }
+
+    const interp = (du < epsilon) ? special : general;
+
+    return Object.assign(interp, { duration: abs(rhoS) / rho });
+  }
+
+  function initFlights(params, camera) {
+    const { ellipsoid, bounds } = params;
+
+    const wScale = 2.0 / (ellipsoid.meanRadius() * Math.PI);
+    let t, interp, active = false;
+
+    function flyTo(position) {
+      if (!bounds.check(position)) {
+        return console.log("spinningBall.flyTo: position out of bounds");
+      }
+
+      const [lon0, lat0, alt0] = camera.position();
+      const [lon1, lat1, alt1] = position;
+      // Scale altitude to be on the same order as lon, lat, and wrap longitude
+      const p0 = [lon0, lat0, alt0 * wScale];
+      const p1 = [lon0 + wrapLongitude(lon1 - lon0), lat1, alt1 * wScale];
+
+      interp = interpolateZoom(p0, p1);
+      t = 0.0;
+      active = true;
+    }
+
+    function update(position, velocity, dt) {
+      if (!active) return;
+      t = Math.min(1.0, t + dt / interp.duration);
+      const newPos = interp(t);
+      newPos[2] /= wScale; // Revert scaling applied in flyTo
+
+      if (t == 1.0) active = false;
+      return position.map((c, i) => newPos[i] - c);
+    }
+
+    return {
+      flyTo, update,
+      active: () => active,
+      cancel: () => (active = false),
+    };
+  }
+
   function oscillatorChange(x, v, t, w0) {
     // For a critically damped oscillator with natural frequency w0, find
     // the change in position x and velocity v over timestep t.  See
@@ -11159,7 +11144,7 @@ function sendTile({ id, tile, transferables }) {
     };
   }
 
-  function initCameraDynamics(ellipsoid, camera, cursor3d) {
+  function initCameraDynamics(ellipsoid, camera, cursor3d, flights) {
     // Velocity is the time differential of camera.position
     const velocity = new Float64Array(3);
 
@@ -11180,29 +11165,33 @@ function sendTile({ id, tile, transferables }) {
     };
 
     function update(newTime) {
-      const deltaTime = newTime - time;
+      const deltaT = newTime - time;
       time = newTime;
       // If timestep too big, wait till next frame to update physics
-      if (deltaTime > 0.25) return false;
+      if (deltaT > 0.25) return false;
 
-      const rotation = (cursor3d.isClicked())
-        ? rotate(camera.position(), velocity, deltaTime)
-        : coast(camera.position(), velocity, deltaTime);
-      camera.update(rotation);
+      if (cursor3d.isClicked()) flights.cancel();
 
-      const rotated = rotation.some(c => c != 0.0);
-      if (!cursor3d.isZooming()) return rotated;
+      const dPos =
+        (cursor3d.isClicked()) ? rotate(camera.position(), velocity, deltaT) :
+        (flights.active()) ? flights.update(camera.position(), velocity, deltaT) :
+        coast(camera.position(), velocity, deltaT);
+      camera.update(dPos);
 
+      const moved = dPos.some(c => c != 0.0);
+      if (!cursor3d.isZooming()) return moved;
+
+      flights.cancel();
       // Update 2D screen position of 3D zoom position
       const visible = camera.ecefToScreenRay(rayVec, cursor3d.zoomPosition);
       if (!visible) {
         velocity.fill(0.0, 2); // TODO: is this needed? Or keep coasting?
         cursor3d.stopZoom();
-        return rotated;
+        return moved;
       }
 
       if (cursor3d.isClicked()) cursor3d.zoomRay.set(rayVec);
-      const zoomChange = zoom(camera.position(), velocity, deltaTime);
+      const zoomChange = zoom(camera.position(), velocity, deltaT);
       camera.update(zoomChange);
       return true;
     }
@@ -11214,7 +11203,8 @@ function sendTile({ id, tile, transferables }) {
 
     const camera = initCamera(params);
     const cursor = initCursor3d(params, camera);
-    const dynamics = initCameraDynamics(ellipsoid, camera, cursor);
+    const flights = initFlights(params, camera);
+    const dynamics = initCameraDynamics(ellipsoid, camera, cursor, flights);
 
     let camMoving, cursorChanged;
 
@@ -11231,6 +11221,7 @@ function sendTile({ id, tile, transferables }) {
       wasTapped: cursor.wasTapped,
       cursorChanged: () => cursorChanged,
 
+      flyTo: (destination) => flights.flyTo(units.convert(destination)),
       update,
     };
 

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -1681,10 +1681,20 @@ void main() {
     const { context, framebuffer } = params;
     const programs = compilePrograms(params);
 
+    let spriteTexture;
+    const spriteSetters = Object.values(programs)
+      .map(({ use, uniformSetters }) => ({ use, set: uniformSetters.sprite }))
+      .filter(setter => setter.set !== undefined);
+
+    function loadSprite(image) {
+      if (image) spriteTexture = context.initTexture({ image, mips: false });
+    }
+
     return { prep, loadAtlas, loadBuffers, loadSprite, initPainter };
 
     function prep() {
       context.bindFramebufferAndSetViewport(framebuffer);
+      spriteSetters.forEach(({ use, set }) => (use(), set(spriteTexture)));
       return context.clear();
     }
 
@@ -1698,14 +1708,6 @@ void main() {
       const program = programs[layer.type];
       if (!program) throw Error("tile-gl loadBuffers: unknown layer type");
       layer.buffers = program.load(layer.buffers);
-    }
-
-    function loadSprite(image) {
-      if (!image) return false;
-      const spriteTex = context.initTexture({ image, mips: false });
-      programs.symbol.use();
-      programs.symbol.uniformSetters.sprite(spriteTex);
-      return true;
     }
 
     function initPainter(style) {

--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -11254,10 +11254,6 @@ function sendTile({ id, tile, transferables }) {
       const cameraPos = ball.cameraPos();
       const alt = cameraPos[2].toPrecision(5);
       toolTip.innerHTML = alt + "km " + lonLatString(...cameraPos);
-
-      if (ball.isOnScene()) {
-        toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos());
-      }
     }
 
     return { update };

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -170,8 +170,9 @@ function createUniformSetter(gl, program, info, textureUnit) {
   }
 
   function buildTextureSetter(bindPoint) {
+    gl.uniform1i(loc, textureUnit);
+
     return function(texture) {
-      gl.uniform1i(loc, textureUnit);
       gl.activeTexture(gl.TEXTURE0 + textureUnit);
       gl.bindTexture(bindPoint, texture);
     };
@@ -179,8 +180,9 @@ function createUniformSetter(gl, program, info, textureUnit) {
 
   function buildTextureArraySetter(bindPoint) {
     const units = Array.from(Array(size), () => textureUnit++);
+    gl.uniform1iv(loc, units);
+
     return function(textures) {
-      gl.uniform1iv(loc, units);
       textures.forEach((texture, i) => {
         gl.activeTexture(gl.TEXTURE0 + units[i]);
         gl.bindTexture(bindPoint, texture);
@@ -197,7 +199,10 @@ function createUniformSetters(gl, program) {
     .filter(info => info !== undefined);
 
   const textureTypes = [gl.SAMPLER_2D, gl.SAMPLER_CUBE];
-  let textureUnit = 0;
+  let textureUnit = 1; // Skip the first texture unit: used for initTexture
+
+  // Make sure program is active, in case we need to set texture units
+  gl.useProgram(program);
 
   return uniformInfo.reduce((d, info) => {
     const { name, type, size } = info;
@@ -213,27 +218,27 @@ function createUniformSetters(gl, program) {
 }
 
 function initAttributes(gl, program) {
-  // Construct a dictionary of the indices of each attribute used by program
+  // Construct a dictionary of the locations of each attribute in the program
   const attrIndices = Array
     .from({ length: gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES) })
-    .map((v, i) => gl.getActiveAttrib(program, i))
-    .reduce((d, { name }, index) => (d[name] = index, d), {});
+    .map((v, i) => gl.getActiveAttrib(program, i).name)
+    .reduce((d, n) => (d[n] = gl.getAttribLocation(program, n), d), {});
 
   // Construct a dictionary of functions to set a constant value for a given
   // vertex attribute, when a per-vertex buffer is not needed
   const constantSetters = Object.entries(attrIndices).reduce((d, [name, i]) => {
     d[name] = function(v) {
       gl.disableVertexAttribArray(i);
-
-      // For float attributes, the supplied value may be a Number
-      if (v.length === undefined) return gl.vertexAttrib1f(i, v);
-
-      if (![1, 2, 3, 4].includes(v.length)) return;
-      const methodName = "vertexAttrib" + v.length + "fv";
-      gl[methodName](i, v);
+      const method = getConstMethod(v.length);
+      if (method) gl[method](i, v);
     };
     return d;
   }, {});
+
+  function getConstMethod(len) {
+    if (len === undefined) return "vertexAttrib1f";
+    if ([1, 2, 3, 4].includes(len)) return "vertexAttrib" + len + "fv";
+  }
 
   function constructVao({ attributes, indices }) {
     const vao = gl.createVertexArray();
@@ -398,6 +403,9 @@ function initTextureMethods(gl) {
     const { width = 1, height = 1 } = (image) ? image : options;
 
     const texture = gl.createTexture();
+
+    // Work with first texture unit. Leave others unchanged (may be in use)
+    gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(target, texture);
 
     gl.texParameteri(target, gl.TEXTURE_WRAP_S, wrapS);
@@ -999,7 +1007,6 @@ in vec3 tileCoords;
 
 uniform vec4 mapCoords;   // x, y, z, extent of tileset[0]
 uniform vec3 mapShift;    // translate and scale of tileset[0]
-
 uniform vec4 screenScale; // 2 / width, -2 / height, pixRatio, cameraScale
 
 vec2 tileToMap(vec2 tilePos) {
@@ -1044,28 +1051,70 @@ float styleScale(vec2 tilePos) {
 }
 `;
 
+var defaultPreamble = `#version 300 es
+
+precision highp float;
+
+uniform vec4 screenScale; // 2 / width, -2 / height, pixRatio, cameraScale
+
+vec2 tileToMap(vec2 tilePos) {
+  return tilePos * screenScale.z;
+}
+
+vec4 mapToClip(vec2 mapPos, float z) {
+  vec2 projected = mapPos * screenScale.xy + vec2(-1.0, 1.0);
+  return vec4(projected, z, 1.0);
+}
+
+float styleScale(vec2 tilePos) {
+  return screenScale.z;
+}
+`;
+
 function setParams$2(userParams) {
   const {
-    context, framebuffer,
-    projScale = false,
-    multiTile = true,
+    context, framebuffer, extraAttributes,
+    preamble = defaultPreamble,
   } = userParams;
 
-  const scaleCode = (projScale) ? mercatorScale : simpleScale;
-  const size = framebuffer.size;
+  return { context, framebuffer, preamble, extraAttributes };
+}
 
-  context.clipRectFlipY = function(x, y, w, h) {
-    const yflip = size.height - y - h;
-    context.clipRect(x, yflip, w, h);
-  };
+var vert$4 = `in vec2 quadPos;
+
+void main() {
+  gl_Position = vec4(quadPos, 0.0, 1.0);
+}
+`;
+
+var frag$4 = `#version 300 es
+
+precision mediump float;
+
+uniform vec4 backgroundColor;
+uniform float backgroundOpacity;
+
+out vec4 pixColor;
+
+void main() {
+  float alpha = backgroundColor.a * backgroundOpacity;
+  pixColor = vec4(backgroundColor.rgb * alpha, alpha);
+}
+`;
+
+function initBackground(context) {
+  const quadPos = context.initQuad();
+
+  const styleKeys = ["background-color", "background-opacity"];
 
   return {
-    context, framebuffer, multiTile,
-    preamble: preamble + scaleCode,
+    vert: vert$4, frag: frag$4, styleKeys,
+    getSpecialAttrs: () => ({ quadPos }),
+    countInstances: () => 1,
   };
 }
 
-var vert$4 = `in vec2 quadPos; // Vertices of the quad instance
+var vert$3 = `in vec2 quadPos; // Vertices of the quad instance
 in vec2 circlePos;
 in float circleRadius;
 in vec4 circleColor;
@@ -1090,7 +1139,7 @@ void main() {
 }
 `;
 
-var frag$4 = `#version 300 es
+var frag$3 = `#version 300 es
 
 precision mediump float;
 
@@ -1112,7 +1161,6 @@ void main() {
 function initCircle(context) {
   const attrInfo = {
     circlePos: { numComponents: 2 },
-    tileCoords: { numComponents: 3 },
     circleRadius: { numComponents: 1 },
     circleColor: { numComponents: 4 },
     circleOpacity: { numComponents: 1 },
@@ -1122,13 +1170,13 @@ function initCircle(context) {
   const styleKeys = ["circle-radius", "circle-color", "circle-opacity"];
 
   return {
-    vert: vert$4, frag: frag$4, attrInfo, styleKeys,
+    vert: vert$3, frag: frag$3, attrInfo, styleKeys,
     getSpecialAttrs: () => ({ quadPos }),
     countInstances: (buffers) => buffers.circlePos.length / 2,
   };
 }
 
-var vert$3 = `in vec2 quadPos;
+var vert$2 = `in vec2 quadPos;
 in vec3 pointA, pointB, pointC, pointD;
 in vec4 lineColor;
 in float lineOpacity, lineWidth, lineGapWidth;
@@ -1242,7 +1290,7 @@ void main() {
 }
 `;
 
-var frag$3 = `#version 300 es
+var frag$2 = `#version 300 es
 
 precision highp float;
 
@@ -1302,7 +1350,6 @@ function initLine(context) {
   const { initQuad, createBuffer, initAttribute } = context;
 
   const attrInfo = {
-    tileCoords: { numComponents: 3 },
     lineColor: { numComponents: 4 },
     lineOpacity: { numComponents: 1 },
     lineWidth: { numComponents: 1 },
@@ -1346,12 +1393,12 @@ function initLine(context) {
   ];
 
   return {
-    vert: vert$3, frag: frag$3, attrInfo, styleKeys, getSpecialAttrs,
+    vert: vert$2, frag: frag$2, attrInfo, styleKeys, getSpecialAttrs,
     countInstances: (buffers) => buffers.lines.length / numComponents - 3,
   };
 }
 
-var vert$2 = `in vec2 position;
+var vert$1 = `in vec2 position;
 in vec4 fillColor;
 in float fillOpacity;
 
@@ -1368,7 +1415,7 @@ void main() {
 }
 `;
 
-var frag$2 = `#version 300 es
+var frag$1 = `#version 300 es
 
 precision mediump float;
 
@@ -1384,7 +1431,6 @@ void main() {
 function initFill() {
   const attrInfo = {
     position: { numComponents: 2, divisor: 0 },
-    tileCoords: { numComponents: 3, divisor: 0 },
     fillColor: { numComponents: 4, divisor: 0 },
     fillOpacity: { numComponents: 1, divisor: 0 },
   };
@@ -1392,95 +1438,39 @@ function initFill() {
   const styleKeys = ["fill-color", "fill-opacity", "fill-translate"];
 
   return {
-    vert: vert$2, frag: frag$2, attrInfo, styleKeys,
+    vert: vert$1, frag: frag$1, attrInfo, styleKeys,
     getSpecialAttrs: () => ({}),
   };
 }
 
-var vert$1 = `in vec2 quadPos;    // Vertices of the quad instance
-in vec3 labelPos0;   // x, y, angle
-in vec4 spritePos;  // dx, dy (relative to labelPos0), w, h
-in vec4 spriteRect; // x, y, w, h
+var vert = `in vec2 quadPos;   // Vertices of the quad instance
+in vec4 labelPos;  // x, y, angle, font size scalar (0 for icons)
+in vec4 glyphPos;  // dx, dy (relative to labelPos), w, h
+in vec4 glyphRect; // x, y, w, h
+
 in float iconOpacity;
 
-out float opacity;
-out vec2 texCoord;
-
-void main() {
-  texCoord = spriteRect.xy + spriteRect.zw * quadPos;
-  opacity = iconOpacity;
-
-  vec2 mapPos = tileToMap(labelPos0.xy);
-
-  // Shift to the appropriate corner of the current instance quad
-  vec2 dPos = (spritePos.xy + spritePos.zw * quadPos) * styleScale(labelPos0.xy);
-
-  float cos_a = cos(labelPos0.z);
-  float sin_a = sin(labelPos0.z);
-  float dx = dPos.x * cos_a - dPos.y * sin_a;
-  float dy = dPos.x * sin_a + dPos.y * cos_a;
-
-  gl_Position = mapToClip(mapPos + vec2(dx, dy), 0.0);
-}
-`;
-
-var frag$1 = `#version 300 es
-
-precision highp float;
-
-uniform sampler2D sprite;
-
-in float opacity;
-in vec2 texCoord;
-
-out vec4 pixColor;
-
-void main() {
-  vec4 texColor = texture(sprite, texCoord);
-  // Input sprite does NOT have pre-multiplied alpha
-  pixColor = vec4(texColor.rgb * texColor.a, texColor.a) * opacity;
-}
-`;
-
-function initSprite(context) {
-  const attrInfo = {
-    labelPos0: { numComponents: 3 },
-    spritePos: { numComponents: 4 },
-    spriteRect: { numComponents: 4 },
-    tileCoords: { numComponents: 3 },
-    iconOpacity: { numComponents: 1 },
-  };
-  const quadPos = context.initQuad({ x0: 0.0, y0: 0.0, x1: 1.0, y1: 1.0 });
-
-  const styleKeys = ["icon-opacity"];
-
-  return {
-    vert: vert$1, frag: frag$1, attrInfo, styleKeys,
-    getSpecialAttrs: () => ({ quadPos }),
-    countInstances: (buffers) => buffers.labelPos0.length / 3,
-  };
-}
-
-var vert = `in vec2 quadPos;  // Vertices of the quad instance
-in vec4 labelPos; // x, y, angle, font size scalar
-in vec4 charPos;  // dx, dy (relative to labelPos), w, h
-in vec4 sdfRect;  // x, y, w, h
 in vec4 textColor;
 in float textOpacity;
 in float textHaloBlur;
 in vec4 textHaloColor;
 in float textHaloWidth;
 
+out vec2 texCoord;
+
+out float opacity;
+
 out vec4 fillColor;
 out vec4 haloColor;
 out vec2 haloSize; // width, blur
-out vec2 texCoord;
 out float taperWidth;
 
 void main() {
-  texCoord = sdfRect.xy + sdfRect.zw * quadPos;
+  // For icons only
+  opacity = iconOpacity;
 
-  taperWidth = labelPos.w * screenScale.z;
+  // For text only
+  taperWidth = labelPos.w * screenScale.z; // == 0.0 for icon glyphs
   haloSize = vec2(textHaloWidth, textHaloBlur) * screenScale.z;
 
   float fillAlpha = textColor.a * textOpacity;
@@ -1488,10 +1478,14 @@ void main() {
   float haloAlpha = textHaloColor.a * textOpacity;
   haloColor = vec4(textHaloColor.rgb * haloAlpha, haloAlpha);
 
+  // Texture coordinates
+  texCoord = glyphRect.xy + glyphRect.zw * quadPos;
+
+  // Compute glyph position. First transform the label origin
   vec2 mapPos = tileToMap(labelPos.xy);
 
   // Shift to the appropriate corner of the current instance quad
-  vec2 dPos = (charPos.xy + charPos.zw * quadPos) * styleScale(labelPos.xy);
+  vec2 dPos = (glyphPos.xy + glyphPos.zw * quadPos) * styleScale(labelPos.xy);
 
   float cos_a = cos(labelPos.z);
   float sin_a = sin(labelPos.z);
@@ -1506,17 +1500,26 @@ var frag = `#version 300 es
 
 precision highp float;
 
-uniform sampler2D sdf;
+uniform sampler2D sprite, sdf;
+
+in vec2 texCoord;
+
+in float opacity;
 
 in vec4 fillColor;
 in vec4 haloColor;
 in vec2 haloSize; // width, blur
-in vec2 texCoord;
-in float taperWidth;
+in float taperWidth; // 0 for icons
 
 out vec4 pixColor;
 
 void main() {
+  // Get color from sprite if this is an icon glyph
+  vec4 spritePix = texture(sprite, texCoord);
+  // Input sprite does NOT have pre-multiplied alpha
+  vec4 iconColor = vec4(spritePix.rgb * spritePix.a, spritePix.a) * opacity;
+
+  // Compute fill and halo color from sdf if this is a text glyph
   float sdfVal = texture(sdf, texCoord).a;
   float screenDist = taperWidth * (191.0 - 255.0 * sdfVal) / 32.0;
 
@@ -1526,17 +1529,19 @@ void main() {
   float haloAlpha = (haloSize.x > 0.0 || haloSize.y > 0.0)
     ? (1.0 - fillAlpha) * smoothstep(-hTaper, -hEdge, -screenDist)
     : 0.0;
+  vec4 textColor = fillColor * fillAlpha + haloColor * haloAlpha;
 
-  pixColor = fillColor * fillAlpha + haloColor * haloAlpha;
+  // Choose icon or text color based on taperWidth value
+  pixColor = (taperWidth == 0.0) ? iconColor : textColor;
 }
 `;
 
-function initText(context) {
+function initSymbol(context) {
   const attrInfo = {
     labelPos: { numComponents: 4 },
-    charPos: { numComponents: 4 },
-    sdfRect: { numComponents: 4 },
-    tileCoords: { numComponents: 3 },
+    glyphPos: { numComponents: 4 },
+    glyphRect: { numComponents: 4 },
+    iconOpacity: { numComponents: 1 },
     textColor: { numComponents: 4 },
     textOpacity: { numComponents: 1 },
     textHaloBlur: { numComponents: 1 },
@@ -1546,6 +1551,7 @@ function initText(context) {
   const quadPos = context.initQuad({ x0: 0.0, y0: 0.0, x1: 1.0, y1: 1.0 });
 
   const styleKeys = [
+    "icon-opacity",
     "text-color",
     "text-opacity",
     "text-halo-blur",
@@ -1560,12 +1566,14 @@ function initText(context) {
   };
 }
 
-function initLoader(context, progInfo, constructVao) {
+function initLoader(context, info, constructVao, extraAttributes) {
   const { initAttribute, initIndices } = context;
-  const { attrInfo, getSpecialAttrs, countInstances } = progInfo;
+  const { attrInfo, getSpecialAttrs, countInstances } = info;
+
+  const allAttrs = Object.assign({}, attrInfo, extraAttributes);
 
   function getAttributes(buffers) {
-    return Object.entries(attrInfo).reduce((d, [key, info]) => {
+    return Object.entries(allAttrs).reduce((d, [key, info]) => {
       const data = buffers[key];
       if (data) d[key] = initAttribute(Object.assign({ data }, info));
       return d;
@@ -1588,43 +1596,44 @@ function initLoader(context, progInfo, constructVao) {
   return (countInstances) ? loadInstanced : loadIndexed;
 }
 
-function initGrid(use, uniformSetters, framebuffer) {
-  const { screenScale, mapCoords, mapShift } = uniformSetters;
+function compilePrograms(params) {
+  const { context, preamble, extraAttributes } = params;
 
-  function setScreen(pixRatio = 1.0, cameraScale = 1.0) {
-    const { width, height } = framebuffer.size;
-    screenScale([2 / width, -2 / height, pixRatio, cameraScale]);
+  const progInfo = {
+    background: initBackground(context),
+    circle: initCircle(context),
+    line: initLine(context),
+    fill: initFill(),
+    symbol: initSymbol(context),
+  };
+
+  function compile(info) {
+    const { vert, frag, styleKeys } = info;
+    const program = context.initProgram(preamble + vert, frag);
+    const { use, constructVao, uniformSetters } = program;
+    const load = initLoader(context, info, constructVao, extraAttributes);
+    return { load, use, uniformSetters, styleKeys };
   }
 
-  function setCoords({ x, y, z }) {
-    const numTiles = 1 << z;
-    const xw = x - Math.floor(x / numTiles) * numTiles;
-    const extent = 512; // TODO: don't assume this!!
-    mapCoords([xw, y, z, extent]);
-    return numTiles;
-  }
-
-  function setShift(tileset, pixRatio = 1) {
-    const { x, y } = tileset[0];
-    const { translate, scale: rawScale } = tileset;
-    const scale = rawScale * pixRatio;
-    const [dx, dy] = [x, y].map((c, i) => (c + translate[i]) * scale);
-    mapShift([dx, dy, scale]);
-    return { translate, scale };
-  }
-
-  return { use, setScreen, setCoords, setShift };
+  return Object.entries(progInfo)
+    .reduce((d, [k, info]) => (d[k] = compile(info), d), {});
 }
 
 function camelCase(hyphenated) {
   return hyphenated.replace(/-([a-z])/gi, (h, c) => c.toUpperCase());
 }
 
-function initStyleProg(style, styleKeys, uniformSetters, spriteTexture) {
-  // TODO: check if spriteTexture is a WebGLTexture
-  const { id, type, paint } = style;
-  const { sdf, sprite } = uniformSetters;
-  const haveSprite = sprite && (spriteTexture instanceof WebGLTexture);
+function initStyleProg(style, program, context, framebuffer) {
+  if (!program) return;
+
+  const { id, type, layout, paint } = style;
+  const { load, use, uniformSetters, styleKeys } = program;
+  const { sdf, screenScale } = uniformSetters;
+
+  if (type === "line") {
+    // We handle line-miter-limit in the paint phase, not layout phase
+    paint["line-miter-limit"] = layout["line-miter-limit"];
+  }
 
   const zoomFuncs = styleKeys
     .filter(styleKey => paint[styleKey].type !== "property")
@@ -1635,87 +1644,124 @@ function initStyleProg(style, styleKeys, uniformSetters, spriteTexture) {
       return (z, f) => set(get(z, f));
     });
 
-  function setStyles(zoom) {
+  function setStyles(zoom, pixRatio = 1.0, cameraScale = 1.0) {
+    use();
     zoomFuncs.forEach(f => f(zoom));
-    if (haveSprite) sprite(spriteTexture);
+    if (!screenScale) return;
+    const { width, height } = framebuffer.size;
+    screenScale([2 / width, -2 / height, pixRatio, cameraScale]);
   }
 
-  const getData = (type !== "symbol") ? getFeatures :
-    (haveSprite) ? getIcons : getText;
+  const getData = (type === "background") ? initBackgroundData() : getFeatures;
+
+  function draw(tile) {
+    const data = getData(tile);
+    if (data) context.draw(data.buffers);
+  }
+
+  function initBackgroundData() {
+    const buffers = load({});
+    return () => ({ buffers });
+  }
 
   function getFeatures(tile) {
-    return tile.data.layers[id];
-  }
-
-  function getIcons(tile) {
-    const layer = tile.data.layers[id];
-    if (!layer) return;
-    const { type, extent, buffers: { sprite } } = layer;
-    if (sprite) return { type, extent, buffers: sprite };
-  }
-
-  function getText(tile) {
     const { layers: { [id]: layer }, atlas } = tile.data;
-    if (!layer || !atlas) return;
-    const { type, extent, buffers: { text } } = layer;
-    if (!text || !sdf) return;
-    sdf(atlas);
-    return { type, extent, buffers: text };
+    if (sdf && atlas) sdf(atlas);
+    return layer;
   }
 
-  return { setStyles, getData };
+  return { id, type, setStyles, getData, uniformSetters, paint: draw };
 }
 
-function initTilePainter(context, program, layer, multiTile) {
-  return (multiTile) ? drawTileset : drawTile;
+function initGL$1(userParams) {
+  const params = setParams$2(userParams);
+  const { context, framebuffer } = params;
+  const programs = compilePrograms(params);
 
-  function drawTile({ tile, zoom, pixRatio = 1.0, cameraScale = 1.0 }) {
-    program.use();
+  return { prep, loadAtlas, loadBuffers, loadSprite, initPainter };
 
-    const data = layer.getData(tile);
-    if (!data) return;
-    const z = (zoom !== undefined) ? zoom : tile.z;
-    layer.setStyles(z);
-
-    program.setScreen(pixRatio, cameraScale);
-    program.setCoords(tile);
-
-    const fakeTileset = [{ x: 0, y: 0 }];
-    Object.assign(fakeTileset, { translate: [0, 0], scale: 512 });
-    program.setShift(fakeTileset, pixRatio);
-
-    context.draw(data.buffers);
+  function prep() {
+    context.bindFramebufferAndSetViewport(framebuffer);
+    return context.clear();
   }
 
-  function drawTileset({ tileset, zoom, pixRatio = 1.0, cameraScale = 1.0 }) {
+  function loadAtlas(atlas) { // TODO: name like loadSprite, different behavior
+    const format = context.gl.ALPHA;
+    const { width, height, data } = atlas;
+    return context.initTexture({ format, width, height, data, mips: false });
+  }
+
+  function loadBuffers(layer) {
+    const program = programs[layer.type];
+    if (!program) throw Error("tile-gl loadBuffers: unknown layer type");
+    layer.buffers = program.load(layer.buffers);
+  }
+
+  function loadSprite(image) {
+    if (!image) return false;
+    const spriteTex = context.initTexture({ image, mips: false });
+    programs.symbol.use();
+    programs.symbol.uniformSetters.sprite(spriteTex);
+    return true;
+  }
+
+  function initPainter(style) {
+    return initStyleProg(style, programs[style.type], context, framebuffer);
+  }
+}
+
+function antiMeridianSplit(tileset) {
+  // At low zooms, some tiles may be repeated on opposite ends of the map
+  // We split them into subsets, one tileset for each copy of the map
+
+  const { 0: { x, z }, translate, scale } = tileset;
+  const numTiles = 1 << z;
+
+  function inRange(tile, shift) {
+    const delta = tile.x - x - shift;
+    return (0 <= delta && delta < numTiles);
+  }
+
+  return [0, 1, 2]
+    .map(repeat => repeat * numTiles)
+    .map(shift => tileset.filter(tile => inRange(tile, shift)))
+    .map(tiles => Object.assign(tiles, { translate, scale }))
+    .filter(subset => subset.length);
+}
+
+function initTilesetPainter(layer, context, fbSize) {
+  const { mapCoords, mapShift } = layer.uniformSetters;
+
+  return (layer.type === "background") ? paintBackground : paintTileset;
+
+  function paintBackground({ zoom, pixRatio = 1.0, cameraScale = 1.0 }) {
+    layer.setStyles(zoom, pixRatio, cameraScale);
+    layer.paint();
+  }
+
+  function paintTileset({ tileset, zoom, pixRatio = 1.0, cameraScale = 1.0 }) {
     if (!tileset || !tileset.length) return;
+    layer.setStyles(zoom, pixRatio, cameraScale);
 
-    program.use();
-    program.setScreen(pixRatio, cameraScale);
-    layer.setStyles(zoom);
+    // Set mapCoords
+    const { x, y, z } = tileset[0];
+    const numTiles = 1 << z;
+    const xw = x - Math.floor(x / numTiles) * numTiles;
+    const extent = 512; // TODO: don't assume this!!
+    mapCoords([xw, y, z, extent]);
 
-    const numTiles = program.setCoords(tileset[0]);
-    const subsets = antiMeridianSplit(tileset, numTiles);
-
-    subsets.forEach(subset => {
-      const { translate, scale } = program.setShift(subset, pixRatio);
-      subset.forEach(t => drawTileBox(t, translate, scale));
-    });
+    // Draw tiles. Split into subsets if they are repeated across antimeridian
+    antiMeridianSplit(tileset).forEach(subset => drawSubset(subset, pixRatio));
   }
 
-  function antiMeridianSplit(tileset, numTiles) {
-    const { translate, scale } = tileset;
-    const { x } = tileset[0];
+  function drawSubset(tileset, pixRatio = 1) {
+    const { 0: { x, y }, translate, scale: rawScale } = tileset;
+    const scale = rawScale * pixRatio;
 
-    // At low zooms, some tiles may be repeated on opposite ends of the map
-    // We split them into subsets, one tileset for each copy of the map
-    return [0, 1, 2].map(repeat => repeat * numTiles).map(shift => {
-      const tiles = tileset.filter(tile => {
-        const delta = tile.x - x - shift;
-        return (delta >= 0 && delta < numTiles);
-      });
-      return Object.assign(tiles, { translate, scale });
-    }).filter(subset => subset.length);
+    const [dx, dy] = [x, y].map((c, i) => (c + translate[i]) * scale);
+    mapShift([dx, dy, scale]);
+
+    tileset.forEach(tile => drawTileBox(tile, translate, scale));
   }
 
   function drawTileBox(box, translate, scale) {
@@ -1724,214 +1770,61 @@ function initTilePainter(context, program, layer, multiTile) {
     if (!data) return;
 
     const [x0, y0] = [x, y].map((c, i) => (c + translate[i]) * scale);
-    context.clipRectFlipY(x0, y0, scale, scale);
+    clipRect(x0, y0, scale, scale);
 
     context.draw(data.buffers);
   }
-}
 
-function initPrograms(context, framebuffer, preamble, multiTile) {
-  return {
-    "circle": setupProgram(initCircle(context)),
-    "line": setupProgram(initLine(context)),
-    "fill": setupProgram(initFill()),
-    "symbol": setupSymbol(),
-  };
-
-  function setupSymbol() {
-    const spriteProg = setupProgram(initSprite(context));
-    const textProg = setupProgram(initText(context));
-
-    function load(buffers) {
-      const loaded = {};
-      if (buffers.spritePos) loaded.sprite = spriteProg.load(buffers);
-      if (buffers.charPos) loaded.text = textProg.load(buffers);
-      return loaded;
-    }
-
-    function initPainter(style, sprite) {
-      const iconPaint = spriteProg.initPainter(style, sprite);
-      const textPaint = textProg.initPainter(style);
-
-      return function(params) {
-        iconPaint(params);
-        textPaint(params);
-      };
-    }
-
-    return { load, initPainter };
-  }
-
-  function setupProgram(progInfo) {
-    const { vert, frag, styleKeys } = progInfo;
-
-    const program = context.initProgram(preamble + vert, frag);
-    const { use, uniformSetters, constructVao } = program;
-
-    const load = initLoader(context, progInfo, constructVao);
-    const grid = initGrid(use, uniformSetters, framebuffer);
-
-    function initPainter(style, sprite) {
-      const styleProg = initStyleProg(style, styleKeys, uniformSetters, sprite);
-      return initTilePainter(context, grid, styleProg, multiTile);
-    }
-
-    return { load, initPainter };
+  function clipRect(x, y, w, h) {
+    const yflip = fbSize.height - y - h;
+    context.clipRect(x, yflip, w, h);
   }
 }
 
-function initBackground(context) {
-  function initPainter({ paint }) {
-    return function({ zoom }) {
-      const opacity = paint["background-opacity"](zoom);
-      const color = paint["background-color"](zoom);
-      context.clear(color.map(c => c * opacity));
-    };
-  }
-
-  return { initPainter };
-}
-
-function initGLpaint(userParams) {
-  const { context, framebuffer, preamble, multiTile } = setParams$2(userParams);
-
-  const programs = initPrograms(context, framebuffer, preamble, multiTile);
-  programs["background"] = initBackground(context);
-
-  function prep() {
-    context.bindFramebufferAndSetViewport(framebuffer);
-    return context.clear();
-  }
-
-  function loadBuffers(layer) {
-    const { type, buffers } = layer;
-
-    const program = programs[type];
-    if (!program) throw "loadBuffers: unknown layer type";
-
-    layer.buffers = program.load(buffers);
-  }
-
-  function loadAtlas(atlas) {
-    const format = context.gl.ALPHA;
-    const { width, height, data } = atlas;
-    return context.initTexture({ format, width, height, data, mips: false });
-  }
-
-  function loadSprite(image) {
-    if (image) return context.initTexture({ image, mips: false });
-  }
-
-  function initPainter(style, sprite) {
-    const { id, type, source, minzoom = 0, maxzoom = 24 } = style;
-
-    const program = programs[type];
-    if (!program) return () => null;
-
-    const { layout, paint } = style;
-    if (type === "line") {
-      // We handle line-miter-limit in the paint phase, not layout phase
-      paint["line-miter-limit"] = layout["line-miter-limit"];
-    }
-    const painter = program.initPainter(style, sprite);
-    return Object.assign(painter, { id, type, source, minzoom, maxzoom });
-  }
-
-  return { prep, loadBuffers, loadAtlas, loadSprite, initPainter };
-}
-
-function setParams$1(userParams) {
-  const gl = userParams.context.gl;
-  if (!(gl instanceof WebGL2RenderingContext)) fail$1("no valid WebGL context");
-
+function initGL(userParams) {
   const {
-    context,
-    framebuffer = { buffer: null, size: gl.canvas },
-    center = [0.0, 0.0], // ASSUMED to be in degrees!
-    zoom = 4,
-    style,
-    mapboxToken,
-    clampY = true,
-    units = "degrees",
+    context, framebuffer,
     projScale = false,
   } = userParams;
 
-  const { buffer, size } = framebuffer;
-  if (!(buffer instanceof WebGLFramebuffer) && buffer !== null) {
-    fail$1("no valid framebuffer");
-  }
+  const scaleCode = (projScale) ? mercatorScale : simpleScale;
 
-  const sizeType =
-    (size && allPosInts(size.clientWidth, size.clientHeight)) ? "client" :
-    (size && allPosInts(size.width, size.height)) ? "raw" :
-    null;
-  if (!sizeType) fail$1("invalid size object in framebuffer");
-  const getViewport = (sizeType === "client")
-    ? () => ([size.clientWidth, size.clientHeight])
-    : () => ([size.width, size.height]);
-
-  const validUnits = ["degrees", "radians", "xy"];
-  if (!validUnits.includes(units)) fail$1("invalid units");
-  const projection = getProjection(units);
-
-  // Convert initial center position from degrees to the specified units
-  if (!checkCoords$1(center, 2)) fail$1("invalid center coordinates");
-  const projCenter = getProjection("degrees").forward(center);
-  if (!all0to1(...projCenter)) fail$1 ("invalid center coordinates");
-  const invCenter = projection.inverse(projCenter);
-
-  if (!Number.isFinite(zoom)) fail$1("invalid zoom value");
-
-  const coords = initCoords({
-    getViewport, projection,
-    center: invCenter,
-    zoom, clampY,
+  const tileContext = initGL$1({
+    context, framebuffer,
+    preamble: preamble + scaleCode,
+    extraAttributes: { tileCoords: { numComponents: 3 } },
   });
 
-  return {
-    gl, framebuffer,
-    projection, coords,
-    style, mapboxToken,
-    context: initGLpaint({ context, framebuffer, projScale }),
+  // Replace initPainter method with a multi-tile program
+  const initPainter = tileContext.initPainter;
+  tileContext.initPainter = function(style) {
+    const layer = initPainter(style);
+    const painter = (layer)
+      ? initTilesetPainter(layer, context, framebuffer.size)
+      : () => null;
+    const { id, type, source, minzoom = 0, maxzoom = 24 } = style;
+    return Object.assign(painter, { id, type, source, minzoom, maxzoom });
   };
-}
 
-function fail$1(message) {
-  throw Error("tile-setter parameter check: " + message + "!");
-}
-
-function allPosInts(...vals) {
-  return vals.every(v => Number.isInteger(v) && v > 0);
-}
-
-function all0to1(...vals) {
-  return vals.every(v => Number.isFinite(v) && v >= 0 && v <= 1);
-}
-
-function checkCoords$1(p, n) {
-  const isArray = Array.isArray(p) ||
-    (ArrayBuffer.isView(p) && !(p instanceof DataView));
-  return isArray && p.length >= n &&
-    p.slice(0, n).every(Number.isFinite);
+  return tileContext;
 }
 
 function expandStyleURL(url, token) {
   const prefix = /^mapbox:\/\/styles\//;
-  if ( !url.match(prefix) ) return url;
+  if (!url.match(prefix)) return url;
   const apiRoot = "https://api.mapbox.com/styles/v1/";
   return url.replace(prefix, apiRoot) + "?access_token=" + token;
 }
 
 function expandSpriteURLs(url, pixRatio, token) {
   // Returns an array containing urls to .png and .json files
-  const { min, max, floor } = Math;
-  const ratio = floor(min(max(1.0, pixRatio), 4.0));
+  const ratio = Math.floor(Math.min(Math.max(1.0, pixRatio), 4.0));
   const ratioStr = (ratio > 1)
     ? "@" + ratio + "x"
     : "";
 
   const prefix = /^mapbox:\/\/sprites\//;
-  if ( !url.match(prefix) ) return {
+  if (!url.match(prefix)) return {
     image: url + ratioStr + ".png",
     meta: url + ratioStr + ".json",
   };
@@ -1948,14 +1841,14 @@ function expandSpriteURLs(url, pixRatio, token) {
 
 function expandTileURL(url, token) {
   const prefix = /^mapbox:\/\//;
-  if ( !url.match(prefix) ) return url;
+  if (!url.match(prefix)) return url;
   const apiRoot = "https://api.mapbox.com/v4/";
   return url.replace(prefix, apiRoot) + ".json?secure&access_token=" + token;
 }
 
 function expandGlyphURL(url, token) {
   const prefix = /^mapbox:\/\/fonts\//;
-  if ( !url.match(prefix) ) return url;
+  if (!url.match(prefix)) return url;
   const apiRoot = "https://api.mapbox.com/fonts/v1/";
   return url.replace(prefix, apiRoot) + "?access_token=" + token;
 }
@@ -2002,6 +1895,12 @@ function getImage(href) {
     img.crossOrigin = "anonymous";
     img.src = href;
   });
+}
+
+function warn(message) {
+  console.log("tile-stencil had a problem loading part of the style document");
+  console.log("  " + message);
+  console.log("  Not a fatal error. Proceeding with the rest of the style...");
 }
 
 function define(constructor, factory, prototype) {
@@ -2678,54 +2577,24 @@ const paintDefaults = {
   },
 };
 
-const refProperties = [
-  "type",
-  "source",
-  "source-layer",
-  "minzoom",
-  "maxzoom",
-  "filter",
-  "layout"
-];
+const refProperties = ["type", "minzoom", "maxzoom",
+  "source", "source-layer", "filter", "layout"];
 
 function derefLayers(layers) {
-  // From mapbox-gl-js, style-spec/deref.js
-  /**
-   * Given an array of layers, some of which may contain `ref` properties
-   * whose value is the `id` of another property, return a new array where
-   * such layers have been augmented with the 'type', 'source', etc. properties
-   * from the parent layer, and the `ref` property has been removed.
-   *
-   * The input is not modified. The output may contain references to portions
-   * of the input.
-   */
-  layers = layers.slice(); // ??? What are we trying to achieve here?
+  // Some layers in Mapbox styles contain a non-standard "ref" property,
+  // pointing to the "id" of another layer.
+  // Augment these layers with properties from the referenced layer
 
-  const map = Object.create(null); // stackoverflow.com/a/21079232/10082269
-  layers.forEach( layer => { map[layer.id] = layer; } );
-
-  for (let i = 0; i < layers.length; i++) {
-    if ("ref" in layers[i]) {
-      layers[i] = deref(layers[i], map[layers[i].ref]);
-    }
-  }
-
-  return layers;
+  const map = layers.reduce((m, l) => (m[l.id] = l, m), {});
+  return layers.map(l => ("ref" in l) ? deref(l, map[l.ref]) : l);
 }
 
 function deref(layer, parent) {
-  const result = {};
+  const result = Object.assign({}, layer);
+  delete result.ref;
 
-  for (const k in layer) {
-    if (k !== "ref") {
-      result[k] = layer[k];
-    }
-  }
-
-  refProperties.forEach((k) => {
-    if (k in parent) {
-      result[k] = parent[k];
-    }
+  refProperties.forEach(k => {
+    if (k in parent) result[k] = parent[k];
   });
 
   return result;
@@ -2758,47 +2627,28 @@ function expandSources(rawSources, token) {
       (url) ? getJSON(expandTileURL(url, token)) : // Get linked TileJSON
       Promise.resolve({}); // No linked info
 
-    return infoPromise.then(info => {
-      // Assign everything to a new object for return.
-      // Note: shallow copy! Some properties may point back to the original
-      // style document, like .vector_layers, .bounds, .center, .extent
-      const updatedSource = Object.assign({}, source, info, { type });
-      return { [key]: updatedSource };
-    });
+    return infoPromise.then(
+      val => ({ [key]: Object.assign({}, source, val, { type }) }),
+      err => (warn("sources." + key + ": " + err.message), ({}))
+    );
   }
 
-  return Promise.allSettled(expandPromises)
-    .then(results => results.reduce(processResult, {}));
-
-  function processResult(sources, result) {
-    if (result.status === "fulfilled") {
-      return Object.assign(sources, result.value);
-    } else {
-      // If one source fails to load, just log the reason and move on
-      warn("Error loading sources: " + result.reason.message);
-      return sources;
-    }
-  }
+  return Promise.all(expandPromises).then(results => {
+    return results.reduce((a, c) => Object.assign(a, c), {});
+  });
 }
 
 function loadSprite(sprite, token) {
   if (!sprite) return;
 
-  const pixRatio = window?.devicePixelRatio || 1.0;
+  const notWorker = (window && window.devicePixelRatio);
+  const pixRatio = (notWorker) ? window.devicePixelRatio : 1.0;
   const urls = expandSpriteURLs(sprite, pixRatio, token);
 
-  return Promise.all([getImage(urls.image), getJSON(urls.meta)])
-    .then( ([image, meta]) => ({ image, meta }) )
-    .catch(err => {
-      // If sprite doesn't load, just log the error and move on
-      warn("Error loading sprite: " + err.message);
-    });
-}
-
-function warn(message) {
-  console.log("tile-stencil had a problem loading part of the style document");
-  console.log("  " + message);
-  console.log("  Not a fatal error. Proceeding with the rest of the style...");
+  return Promise.all([getImage(urls.image), getJSON(urls.meta)]).then(
+    ([image, meta]) => ({ image, meta }),
+    err => warn("sprite: " + err.message)
+  );
 }
 
 function getStyleFuncs(inputLayer) {
@@ -2837,6 +2687,81 @@ function checkStyle(doc) {
     null;
 
   return (error) ? Promise.reject(error) : doc;
+}
+
+function setParams$1(userParams) {
+  const gl = userParams.context.gl;
+  if (!(gl instanceof WebGL2RenderingContext)) fail$1("no valid WebGL context");
+
+  const {
+    context,
+    framebuffer = { buffer: null, size: gl.canvas },
+    center = [0.0, 0.0], // ASSUMED to be in degrees!
+    zoom = 4,
+    style,
+    mapboxToken,
+    clampY = true,
+    units = "degrees",
+    projScale = false,
+  } = userParams;
+
+  const { buffer, size } = framebuffer;
+  if (!(buffer instanceof WebGLFramebuffer) && buffer !== null) {
+    fail$1("no valid framebuffer");
+  }
+
+  const sizeType =
+    (size && allPosInts(size.clientWidth, size.clientHeight)) ? "client" :
+    (size && allPosInts(size.width, size.height)) ? "raw" :
+    null;
+  if (!sizeType) fail$1("invalid size object in framebuffer");
+  const getViewport = (sizeType === "client")
+    ? () => ([size.clientWidth, size.clientHeight])
+    : () => ([size.width, size.height]);
+
+  const validUnits = ["degrees", "radians", "xy"];
+  if (!validUnits.includes(units)) fail$1("invalid units");
+  const projection = getProjection(units);
+
+  // Convert initial center position from degrees to the specified units
+  if (!checkCoords$1(center, 2)) fail$1("invalid center coordinates");
+  const projCenter = getProjection("degrees").forward(center);
+  if (!all0to1(...projCenter)) fail$1 ("invalid center coordinates");
+  const invCenter = projection.inverse(projCenter);
+
+  if (!Number.isFinite(zoom)) fail$1("invalid zoom value");
+
+  const coords = initCoords({
+    getViewport, projection,
+    center: invCenter,
+    zoom, clampY,
+  });
+
+  return {
+    gl, framebuffer,
+    projection, coords,
+    style, mapboxToken,
+    context: initGL({ context, framebuffer, projScale }),
+  };
+}
+
+function fail$1(message) {
+  throw Error("tile-setter parameter check: " + message + "!");
+}
+
+function allPosInts(...vals) {
+  return vals.every(v => Number.isInteger(v) && v > 0);
+}
+
+function all0to1(...vals) {
+  return vals.every(v => Number.isFinite(v) && v >= 0 && v <= 1);
+}
+
+function checkCoords$1(p, n) {
+  const isArray = Array.isArray(p) ||
+    (ArrayBuffer.isView(p) && !(p instanceof DataView));
+  return isArray && p.length >= n &&
+    p.slice(0, n).every(Number.isFinite);
 }
 
 initZeroTimeouts$1();
@@ -3040,13 +2965,13 @@ function setParams$3(userParams) {
     source, glyphs, layers, spriteData,
   } = userParams;
 
-  if (source?.type === "vector") {
+  if (source && source.type === "vector") {
     if (!source.tiles.length) fail$2("no valid vector tile endpoint");
-  } else if (source?.type !== "geojson") {
+  } else if (source && source.type !== "geojson") {
     fail$2("no valid vector or geojson source");
   }
 
-  if (!layers?.length) fail$2 ("no valid array of style layers");
+  if (!layers || !layers.length) fail$2 ("no valid array of style layers");
   if (!layers.every(isVector)) fail$2("not all layers are vector layers");
 
   const sameSource = layers.every(l => l.source === layers[0].source);
@@ -6466,28 +6391,26 @@ function updateFonts(fonts, feature) {
   return fonts;
 }
 
-function initStyleGetters(keys, { layout, paint }) {
-  const layoutFuncs = keys.layout
-    .map(k => ([camelCase$1(k), layout[k]]));
+function initStyleGetters(keys, { layout }) {
+  const styleFuncs = keys.map(k => ([layout[k], camelCase$1(k)]));
 
-  const bufferFuncs = keys.paint
-    .filter(k => paint[k].type === "property")
-    .map(k => ([camelCase$1(k), paint[k]]));
-
-  return function(zoom, feature) {
-    const layoutVals = layoutFuncs
-      .reduce((d, [k, f]) => (d[k] = f(zoom, feature), d), {});
-
-    const bufferVals = bufferFuncs
-      .reduce((d, [k, f]) => (d[k] = f(zoom, feature), d), {});
-
-    return { layoutVals, bufferVals };
+  return function(z, feature) {
+    return styleFuncs.reduce((d, [g, k]) => (d[k] = g(z, feature), d), {});
   };
 }
 
 function camelCase$1(hyphenated) {
   return hyphenated.replace(/-([a-z])/gi, (h, c) => c.toUpperCase());
 }
+
+const styleKeys = [
+  "icon-opacity",
+  "text-color",
+  "text-opacity",
+  "text-halo-blur",
+  "text-halo-color",
+  "text-halo-width",
+];
 
 function getBox(w, h, anchor, offset) {
   const [sx, sy] = getBoxShift(anchor);
@@ -6548,15 +6471,13 @@ function initIcon(style, spriteData = {}) {
   const { image: { width, height } = {}, meta = {} } = spriteData;
   if (!width || !height) return () => undefined;
 
-  const getStyles = initStyleGetters(iconKeys, style);
+  const getStyles = initStyleGetters(iconLayoutKeys, style);
 
   return function(feature, tileCoords) {
     const sprite = getSprite(feature.spriteID);
     if (!sprite) return;
 
-    const { layoutVals, bufferVals } = getStyles(tileCoords.z, feature);
-    const icon = layoutSprite(sprite, layoutVals);
-    return Object.assign(icon, { bufferVals }); // TODO: rethink this
+    return layoutSprites(sprite, getStyles(tileCoords.z, feature));
   };
 
   function getSprite(spriteID) {
@@ -6572,21 +6493,16 @@ function initIcon(style, spriteData = {}) {
   }
 }
 
-const iconKeys = {
-  layout: [
-    "icon-anchor",
-    "icon-offset",
-    "icon-padding",
-    "icon-rotation-alignment",
-    "icon-size",
-  ],
-  paint: [
-    "icon-opacity",
-  ],
-};
+const iconLayoutKeys = [
+  "icon-anchor",
+  "icon-offset",
+  "icon-padding",
+  "icon-rotation-alignment",
+  "icon-size",
+];
 
-function layoutSprite(sprite, styleVals) {
-  const { metrics: { w, h }, spriteRect } = sprite;
+function layoutSprites(sprite, styleVals) {
+  const { metrics: { w, h }, spriteRect: rect } = sprite;
 
   const { iconAnchor, iconOffset, iconSize, iconPadding } = styleVals;
   const iconbox = getBox(w, h, iconAnchor, iconOffset);
@@ -6594,7 +6510,8 @@ function layoutSprite(sprite, styleVals) {
 
   const pos = [iconbox.x, iconbox.y, w, h].map(c => c * iconSize);
 
-  return { pos, rect: spriteRect, bbox };
+  // Structure return value to match ../text
+  return Object.assign([{ pos, rect }], { bbox, fontScalar: 0.0 });
 }
 
 const whitespace = {
@@ -6831,43 +6748,33 @@ function layout(glyphs, styleVals) {
 }
 
 function initText(style) {
-  const getStyles = initStyleGetters(textKeys, style);
+  const getStyles = initStyleGetters(textLayoutKeys, style);
 
   return function(feature, tileCoords, atlas) {
     const glyphs = getGlyphs(feature, atlas);
     if (!glyphs || !glyphs.length) return;
 
-    const { layoutVals, bufferVals } = getStyles(tileCoords.z, feature);
-    const chars = layout(glyphs, layoutVals);
-    return Object.assign(chars, { bufferVals }); // TODO: rethink this
+    return layout(glyphs, getStyles(tileCoords.z, feature));
   };
 }
 
-const textKeys = {
-  layout: [
-    "symbol-placement", // TODO: both here and in ../anchors/anchors.js
-    "text-anchor",
-    "text-justify",
-    "text-letter-spacing",
-    "text-line-height",
-    "text-max-width",
-    "text-offset",
-    "text-padding",
-    "text-rotation-alignment",
-    "text-size",
-  ],
-  paint: [
-    "text-color",
-    "text-opacity",
-    "text-halo-blur",
-    "text-halo-color",
-    "text-halo-width",
-  ],
-};
+const textLayoutKeys = [
+  "symbol-placement", // TODO: both here and in ../anchors/anchors.js
+  "text-anchor",
+  "text-justify",
+  "text-letter-spacing",
+  "text-line-height",
+  "text-max-width",
+  "text-offset",
+  "text-padding",
+  "text-rotation-alignment",
+  "text-size",
+];
 
 function getGlyphs(feature, atlas) {
+  if (!atlas) return;
   const { charCodes, font } = feature;
-  const positions = atlas?.positions[font];
+  const positions = atlas.positions[font];
   if (!positions || !charCodes || !charCodes.length) return;
 
   const { width, height } = atlas.image;
@@ -6894,9 +6801,9 @@ function buildCollider(placement) {
 
 function pointCollision(icon, text, anchor, tree) {
   const [x0, y0] = anchor;
-  const boxes = [];
-  if (icon) boxes.push(formatBox(x0, y0, icon.bbox));
-  if (text) boxes.push(formatBox(x0, y0, text.bbox));
+  const boxes = [icon, text]
+    .filter(label => label !== undefined)
+    .map(label => formatBox(x0, y0, label.bbox));
 
   if (boxes.some(tree.collides, tree)) return true;
   // TODO: drop if outside tile?
@@ -6919,17 +6826,16 @@ function lineCollision(icon, text, anchor, tree) {
   const sin_a = sin$1(angle);
   const rotate = ([x, y]) => [x * cos_a - y * sin_a, x * sin_a + y * cos_a];
 
-  const boxes = [];
-  if (text) text.map(c => getCharBbox(c.pos, rotate))
-    .map(bbox => formatBox(x0, y0, bbox))
-    .forEach(box => boxes.push(box));
-  if (icon) boxes.push(formatBox(x0, y0, getCharBbox(icon.pos, rotate)));
+  const boxes = [icon, text].flat()
+    .filter(glyph => glyph !== undefined)
+    .map(g => getGlyphBbox(g.pos, rotate))
+    .map(bbox => formatBox(x0, y0, bbox));
 
   if (boxes.some(tree.collides, tree)) return true;
   boxes.forEach(tree.insert, tree);
 }
 
-function getCharBbox([x, y, w, h], rotate) {
+function getGlyphBbox([x, y, w, h], rotate) {
   const corners = [
     [x, y], [x + w, y],
     [x, y + h], [x + w, y + h]
@@ -7141,7 +7047,9 @@ function getLineAnchors(geometry, extent, icon, text, layoutVals) {
   const alignment = (text) ? textRotationAlignment : iconRotationAlignment;
   const keepUpright = (text) ? textKeepUpright : iconKeepUpright;
 
-  const box = mergeBoxes(icon?.bbox, text?.bbox);
+  const iconbox = (icon) ? icon.bbox : undefined;
+  const textbox = (text) ? text.bbox : undefined;
+  const box = mergeBoxes(iconbox, textbox);
   const labelLength = (alignment === "viewport") ? 0.0 : box[2] - box[0];
   const spacing = max(symbolSpacing, labelLength + symbolSpacing / 4);
 
@@ -7177,10 +7085,10 @@ function getLineAnchors(geometry, extent, icon, text, layoutVals) {
 }
 
 function initAnchors(style) {
-  const getStyles = initStyleGetters(symbolKeys, style);
+  const getStyles = initStyleGetters(symbolLayoutKeys, style);
 
   return function(feature, tileCoords, icon, text, tree) {
-    const { layoutVals } = getStyles(tileCoords.z, feature);
+    const layoutVals = getStyles(tileCoords.z, feature);
     const collides = buildCollider(layoutVals.symbolPlacement);
 
     // TODO: get extent from tile?
@@ -7189,19 +7097,16 @@ function initAnchors(style) {
   };
 }
 
-const symbolKeys = {
-  layout: [
-    "symbol-placement",
-    "symbol-spacing",
-    // TODO: these are in 2 places: here and in the text getter
-    "text-rotation-alignment",
-    "text-size",
-    "icon-rotation-alignment",
-    "icon-keep-upright",
-    "text-keep-upright",
-  ],
-  paint: [],
-};
+const symbolLayoutKeys = [
+  "symbol-placement",
+  "symbol-spacing",
+  // TODO: these are in 2 places: here and in the text getter
+  "text-rotation-alignment",
+  "text-size",
+  "icon-rotation-alignment",
+  "icon-keep-upright",
+  "text-keep-upright",
+];
 
 function getAnchors(geometry, extent, icon, text, layoutVals) {
   switch (layoutVals.symbolPlacement) {
@@ -7225,54 +7130,22 @@ function getPointAnchors({ type, coordinates }) {
   }
 }
 
-function getBuffers(icon, text, anchor, tileCoords) {
-  const iconBuffers = getIconBuffers(icon, anchor, tileCoords);
-  const textBuffers = getTextBuffers(text, anchor, tileCoords);
-  return mergeBuffers(iconBuffers, textBuffers);
+function getBuffers(icon, text, anchor) {
+  const iconBuffers = buildBuffers(icon, anchor);
+  const textBuffers = buildBuffers(text, anchor);
+  return [iconBuffers, textBuffers].filter(b => b !== undefined);
 }
 
-function getIconBuffers(icon, anchor, { z, x, y }) {
-  if (!icon) return;
+function buildBuffers(glyphs, anchor) {
+  if (!glyphs) return;
 
-  // NOTE: mergeBuffers may overwrite tileCoords with the text buffer of the
-  // same name. This is OK because the text buffer, if it exists, is longer
-  const buffers = {
-    spriteRect: icon.rect,
-    spritePos: icon.pos,
-    labelPos0: [...anchor],
-    tileCoords: [x, y, z],
+  const origin = [...anchor, glyphs.fontScalar];
+
+  return {
+    glyphRect: glyphs.flatMap(g => g.rect),
+    glyphPos: glyphs.flatMap(g => g.pos),
+    labelPos: glyphs.flatMap(() => origin),
   };
-
-  Object.entries(icon.bufferVals).forEach(([key, val]) => {
-    buffers[key] = val;
-  });
-
-  return buffers;
-}
-
-function getTextBuffers(text, anchor, { z, x, y }) {
-  if (!text) return;
-
-  const origin = [...anchor, text.fontScalar];
-
-  const buffers = {
-    sdfRect: text.flatMap(c => c.rect),
-    charPos: text.flatMap(c => c.pos),
-    labelPos: text.flatMap(() => origin),
-    tileCoords: text.flatMap(() => [x, y, z]),
-  };
-
-  Object.entries(text.bufferVals).forEach(([key, val]) => {
-    buffers[key] = text.flatMap(() => val);
-  });
-
-  return buffers;
-}
-
-function mergeBuffers(buf1, buf2) {
-  if (!buf1) return buf2;
-  if (!buf2) return buf1;
-  return Object.assign(buf1, buf2);
 }
 
 function initShaping(style, spriteData) {
@@ -7280,7 +7153,9 @@ function initShaping(style, spriteData) {
   const getText = initText(style);
   const getAnchors = initAnchors(style);
 
-  return function(feature, tileCoords, atlas, tree) {
+  return { serialize, getLength, styleKeys };
+
+  function serialize(feature, tileCoords, atlas, tree) {
     // tree is an RBush from the 'rbush' module. NOTE: will be updated!
 
     const icon = getIcon(feature, tileCoords);
@@ -7291,9 +7166,13 @@ function initShaping(style, spriteData) {
     if (!anchors || !anchors.length) return;
 
     return anchors
-      .map(anchor => getBuffers(icon, text, anchor, tileCoords))
+      .flatMap(anchor => getBuffers(icon, text, anchor))
       .reduce(combineBuffers, {});
-  };
+  }
+
+  function getLength(buffers) {
+    return buffers.labelPos.length / 4;
+  }
 }
 
 function combineBuffers(dict, buffers) {
@@ -7304,14 +7183,32 @@ function combineBuffers(dict, buffers) {
   return dict;
 }
 
+function setParams(userParams) {
+  const { glyphs, spriteData, layers } = userParams;
+
+  if (!layers || !layers.length) fail("no valid array of style layers");
+  const parsedStyles = layers.map(getStyleFuncs);
+
+  const glyphsOK = ["string", "undefined"].includes(typeof glyphs);
+  if (!glyphsOK) fail("glyphs must be a string URL");
+
+  const getAtlas = initAtlasGetter({ parsedStyles, glyphEndpoint: glyphs });
+
+  return { parsedStyles, spriteData, getAtlas };
+}
+
+function fail(message) {
+  throw Error("tile-gl initSerializer: " + message);
+}
+
 const circleInfo = {
   styleKeys: ["circle-radius", "circle-color", "circle-opacity"],
   serialize: flattenPoints,
   getLength: (buffers) => buffers.circlePos.length / 2,
 };
 
-function flattenPoints(geometry) {
-  const { type, coordinates } = geometry;
+function flattenPoints(feature) {
+  const { type, coordinates } = feature.geometry;
   if (!coordinates || !coordinates.length) return;
 
   switch (type) {
@@ -7335,8 +7232,8 @@ const lineInfo = {
   getLength: (buffers) => buffers.lines.length / 3,
 };
 
-function flattenLines(geometry) {
-  const { type, coordinates } = geometry;
+function flattenLines(feature) {
+  const { type, coordinates } = feature.geometry;
   if (!coordinates || !coordinates.length) return;
 
   switch (type) {
@@ -8081,8 +7978,8 @@ const fillInfo = {
   getLength: (buffers) => buffers.position.length / 2,
 };
 
-function triangulate(geometry) {
-  const { type, coordinates } = geometry;
+function triangulate(feature) {
+  const { type, coordinates } = feature.geometry;
   if (!coordinates || !coordinates.length) return;
 
   switch (type) {
@@ -8110,16 +8007,14 @@ function camelCase(hyphenated) {
   return hyphenated.replace(/-([a-z])/gi, (h, c) => c.toUpperCase());
 }
 
-function initFeatureSerializer(style, spriteData) {
-  const { type, paint } = style;
-
-  switch (type) {
+function getSerializeInfo(style, spriteData) {
+  switch (style.type) {
     case "circle":
-      return initParsing(paint, circleInfo);
+      return circleInfo;
     case "line":
-      return initParsing(paint, lineInfo);
+      return lineInfo;
     case "fill":
-      return initParsing(paint, fillInfo);
+      return fillInfo;
     case "symbol":
       return initShaping(style, spriteData);
     default:
@@ -8127,20 +8022,21 @@ function initFeatureSerializer(style, spriteData) {
   }
 }
 
-function initParsing(paint, info) {
+function initFeatureSerializer(paint, info) {
   const { styleKeys, serialize, getLength } = info;
-  const dataFuncs = styleKeys.filter(k => paint[k].type === "property")
+
+  const dataFuncs = styleKeys
+    .filter(k => paint[k].type === "property")
     .map(k => ([paint[k], camelCase(k)]));
 
-  return function(feature, { z, x, y }) {
-    const buffers = serialize(feature.geometry);
+  return function(feature, tileCoords, atlas, tree) {
+    const buffers = serialize(feature, tileCoords, atlas, tree);
     if (!buffers) return;
 
     const dummy = Array.from({ length: getLength(buffers) });
 
-    buffers.tileCoords = dummy.flatMap(() => [x, y, z]);
     dataFuncs.forEach(([get, key]) => {
-      const val = get(null, feature);
+      const val = get(null, feature); // Note: could be an Array
       buffers[key] = dummy.flatMap(() => val);
     });
 
@@ -8148,17 +8044,18 @@ function initParsing(paint, info) {
   };
 }
 
-function concatBuffers(features) {
+function concatBuffers(buffers) {
   // Concatenate the buffers from all the features
-  const arrays = features.map(f => f.buffers).reduce(appendBuffers, {});
+  const arrays = buffers.reduce(appendBuffers, {});
 
   // Convert to TypedArrays (now that the lengths are finalized)
-  return Object.entries(arrays).reduce((d, [key, buffer]) => {
-    d[key] = (key === "indices")
-      ? new Uint32Array(buffer)
-      : new Float32Array(buffer);
-    return d;
-  }, {});
+  return Object.entries(arrays)
+    .reduce((d, [k, a]) => (d[k] = makeTypedArray(k, a), d), {});
+}
+
+function makeTypedArray(key, array) {
+  const type = (key === "indices") ? Uint32Array : Float32Array;
+  return new type(array);
 }
 
 function appendBuffers(buffers, newBuffers) {
@@ -8181,25 +8078,24 @@ function appendBuffers(buffers, newBuffers) {
 function initLayerSerializer(style, spriteData) {
   const { id, type, interactive } = style;
 
-  const transform = initFeatureSerializer(style, spriteData);
+  const info = getSerializeInfo(style, spriteData);
+  const transform = initFeatureSerializer(style.paint, info);
   if (!transform) return;
 
   return function(layer, tileCoords, atlas, tree) {
     const { extent, features } = layer;
 
-    const transformed = features.map(feature => {
-      const { properties, geometry } = feature;
-      const buffers = transform(feature, tileCoords, atlas, tree);
-      // If no buffers, skip entire feature (it won't be rendered)
-      if (buffers) return { properties, geometry, buffers };
-    }).filter(f => f !== undefined);
+    const transformed = features
+      .map(f => transform(f, tileCoords, atlas, tree))
+      .filter(f => f !== undefined);
 
     if (!transformed.length) return;
 
-    const newLayer = { type, extent, buffers: concatBuffers(transformed) };
+    const buffers = concatBuffers(transformed);
+    const length = info.getLength(buffers);
+    const newLayer = { type, extent, buffers, length };
 
-    if (interactive) newLayer.features = transformed
-      .map(({ properties, geometry }) => ({ properties, geometry }));
+    if (interactive) newLayer.features = features.slice();
 
     return { [id]: newLayer };
   };
@@ -8770,52 +8666,57 @@ function multiSelect(arr, left, right, n, compare) {
     }
 }
 
-function initTileSerializer(styles, spriteData) {
-  const layerSerializers = styles
+function initSerializer$1(userParams) {
+  const { parsedStyles, spriteData, getAtlas } = setParams(userParams);
+
+  const layerSerializers = parsedStyles
     .reduce((d, s) => (d[s.id] = initLayerSerializer(s, spriteData), d), {});
 
-  return function(layers, tileCoords, atlas) {
+  return function(source, tileCoords) {
+    return getAtlas(source, tileCoords.z)
+      .then(atlas => process(source, tileCoords, atlas));
+  };
+
+  function process(source, coords, atlas) {
     const tree = new RBush();
 
-    return Object.entries(layers)
+    function serializeLayer([id, layer]) {
+      const serialize = layerSerializers[id];
+      if (serialize) return serialize(layer, coords, atlas, tree);
+    }
+
+    const layers = Object.entries(source)
       .reverse() // Reverse order for collision checks
-      .map(([id, layer]) => {
-        const serialize = layerSerializers[id];
-        if (serialize) return serialize(layer, tileCoords, atlas, tree);
-      })
+      .map(serializeLayer)
       .reverse()
       .reduce((d, l) => Object.assign(d, l), {});
-  };
+
+    // Note: atlas.data.buffer is a Transferable
+    return { atlas: atlas.image, layers };
+  }
+}
+
+function addTileCoords(tile, coords) {
+  const { z, x, y } = coords;
+
+  Object.values(tile.layers).forEach(layer => {
+    const { length, buffers } = layer;
+    const coordArray = Array.from({ length }).flatMap(() => [x, y, z]);
+    buffers.tileCoords = new Float32Array(coordArray);
+  });
+
+  return tile;
 }
 
 function initSerializer(userParams) {
-  const { glyphEndpoint, spriteData, layers } = setParams(userParams);
-  const parsedStyles = layers.map(getStyleFuncs);
+  const serialize = initSerializer$1(userParams);
 
-  const getAtlas = initAtlasGetter({ parsedStyles, glyphEndpoint });
-  const process = initTileSerializer(parsedStyles, spriteData);
+  function wrapSerialize(source, tileCoords) {
+    return serialize(source, tileCoords)
+      .then(tile => addTileCoords(tile, tileCoords));
+  }
 
-  return function(source, tileCoords) {
-    return getAtlas(source, tileCoords.z).then(atlas => {
-      const layers = process(source, tileCoords, atlas);
-
-      // Note: atlas.data.buffer is a Transferable
-      return { atlas: atlas.image, layers };
-    });
-  };
-}
-
-function setParams({ glyphs, spriteData, layers }) {
-  if (!layers || !layers.length) fail("no valid array of style layers");
-
-  const glyphsOK = ["string", "undefined"].includes(typeof glyphs);
-  if (!glyphsOK) fail("glyphs must be a string URL");
-
-  return { glyphEndpoint: glyphs, spriteData, layers };
-}
-
-function fail(message) {
-  throw Error("tile-gl initSerializer: " + message);
+  return wrapSerialize;
 }
 
 function initTileFunctions({ source, glyphs, spriteData, layers }) {
@@ -9328,13 +9229,11 @@ function initRenderer(context, coords, style) {
   const { PI, cosh } = Math;
   const { layers, spriteData } = style;
 
-  const sprite = context.loadSprite(spriteData?.image);
+  if (spriteData) context.loadSprite(spriteData.image);
 
   const painters = layers.map(layer => {
-    const painter = context.initPainter(getStyleFuncs(layer), sprite);
-
-    painter.visible = () => layer.visible;
-    return painter;
+    const painter = context.initPainter(getStyleFuncs(layer));
+    return Object.assign(painter, { visible: () => layer.visible });
   });
 
   return function(tilesets, pixRatio = 1, dzScale = 1) {
@@ -11004,6 +10903,92 @@ function initCursor3d(params, camera) {
   }
 }
 
+function interpolateZoom(p0, p1) {
+  const [ux0, uy0, w0] = p0;
+  const [ux1, uy1, w1] = p1;
+
+  const { cosh, sinh, tanh, exp, log, hypot, SQRT2, abs } = Math;
+  const rho = SQRT2;
+  const epsilon = 1e-6;
+
+  const dx = ux1 - ux0;
+  const dy = uy1 - uy0;
+  const du = hypot(dx, dy);
+
+  const rho2du = rho * rho * du;
+  const uScale = w0 / rho2du;
+
+  const b0 = (w1 * w1 - w0 * w0 + rho2du * rho2du) / (2 * w0 * rho2du);
+  const b1 = (w1 * w1 - w0 * w0 - rho2du * rho2du) / (2 * w1 * rho2du);
+  const r0 = log(hypot(b0, 1) - b0);
+  const r1 = log(hypot(b1, 1) - b1);
+  const coshr0 = cosh(r0);
+  const sinhr0 = sinh(r0);
+
+  const rhoS = (du < epsilon) ? log(w1 / w0) : (r1 - r0);
+
+  function special(t) { // Special case for u0 =~ u1
+    return [
+      ux0 + t * dx,
+      uy0 + t * dy,
+      w0 * exp(rhoS * t),
+    ];
+  }
+
+  function general(t) { // General case
+    const uarg = rhoS * t + r0;
+    const u = uScale * (coshr0 * tanh(uarg) - sinhr0);
+    return [
+      ux0 + u * dx,
+      uy0 + u * dy,
+      w0 * coshr0 / cosh(uarg)
+    ];
+  }
+
+  const interp = (du < epsilon) ? special : general;
+
+  return Object.assign(interp, { duration: abs(rhoS) / rho });
+}
+
+function initFlights(params, camera) {
+  const { ellipsoid, bounds } = params;
+
+  const wScale = 2.0 / (ellipsoid.meanRadius() * Math.PI);
+  let t, interp, active = false;
+
+  function flyTo(position) {
+    if (!bounds.check(position)) {
+      return console.log("spinningBall.flyTo: position out of bounds");
+    }
+
+    const [lon0, lat0, alt0] = camera.position();
+    const [lon1, lat1, alt1] = position;
+    // Scale altitude to be on the same order as lon, lat, and wrap longitude
+    const p0 = [lon0, lat0, alt0 * wScale];
+    const p1 = [lon0 + wrapLongitude(lon1 - lon0), lat1, alt1 * wScale];
+
+    interp = interpolateZoom(p0, p1);
+    t = 0.0;
+    active = true;
+  }
+
+  function update(position, velocity, dt) {
+    if (!active) return;
+    t = Math.min(1.0, t + dt / interp.duration);
+    const newPos = interp(t);
+    newPos[2] /= wScale; // Revert scaling applied in flyTo
+
+    if (t == 1.0) active = false;
+    return position.map((c, i) => newPos[i] - c);
+  }
+
+  return {
+    flyTo, update,
+    active: () => active,
+    cancel: () => (active = false),
+  };
+}
+
 function oscillatorChange(x, v, t, w0) {
   // For a critically damped oscillator with natural frequency w0, find
   // the change in position x and velocity v over timestep t.  See
@@ -11156,7 +11141,7 @@ function initCoast(ellipsoid) {
   };
 }
 
-function initCameraDynamics(ellipsoid, camera, cursor3d) {
+function initCameraDynamics(ellipsoid, camera, cursor3d, flights) {
   // Velocity is the time differential of camera.position
   const velocity = new Float64Array(3);
 
@@ -11177,29 +11162,33 @@ function initCameraDynamics(ellipsoid, camera, cursor3d) {
   };
 
   function update(newTime) {
-    const deltaTime = newTime - time;
+    const deltaT = newTime - time;
     time = newTime;
     // If timestep too big, wait till next frame to update physics
-    if (deltaTime > 0.25) return false;
+    if (deltaT > 0.25) return false;
 
-    const rotation = (cursor3d.isClicked())
-      ? rotate(camera.position(), velocity, deltaTime)
-      : coast(camera.position(), velocity, deltaTime);
-    camera.update(rotation);
+    if (cursor3d.isClicked()) flights.cancel();
 
-    const rotated = rotation.some(c => c != 0.0);
-    if (!cursor3d.isZooming()) return rotated;
+    const dPos =
+      (cursor3d.isClicked()) ? rotate(camera.position(), velocity, deltaT) :
+      (flights.active()) ? flights.update(camera.position(), velocity, deltaT) :
+      coast(camera.position(), velocity, deltaT);
+    camera.update(dPos);
 
+    const moved = dPos.some(c => c != 0.0);
+    if (!cursor3d.isZooming()) return moved;
+
+    flights.cancel();
     // Update 2D screen position of 3D zoom position
     const visible = camera.ecefToScreenRay(rayVec, cursor3d.zoomPosition);
     if (!visible) {
       velocity.fill(0.0, 2); // TODO: is this needed? Or keep coasting?
       cursor3d.stopZoom();
-      return rotated;
+      return moved;
     }
 
     if (cursor3d.isClicked()) cursor3d.zoomRay.set(rayVec);
-    const zoomChange = zoom(camera.position(), velocity, deltaTime);
+    const zoomChange = zoom(camera.position(), velocity, deltaT);
     camera.update(zoomChange);
     return true;
   }
@@ -11211,7 +11200,8 @@ function init(userParams) {
 
   const camera = initCamera(params);
   const cursor = initCursor3d(params, camera);
-  const dynamics = initCameraDynamics(ellipsoid, camera, cursor);
+  const flights = initFlights(params, camera);
+  const dynamics = initCameraDynamics(ellipsoid, camera, cursor, flights);
 
   let camMoving, cursorChanged;
 
@@ -11228,6 +11218,7 @@ function init(userParams) {
     wasTapped: cursor.wasTapped,
     cursorChanged: () => cursorChanged,
 
+    flyTo: (destination) => flights.flyTo(units.convert(destination)),
     update,
   };
 

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -11251,10 +11251,6 @@ function initToolTip(ball, globeDiv) {
     const cameraPos = ball.cameraPos();
     const alt = cameraPos[2].toPrecision(5);
     toolTip.innerHTML = alt + "km " + lonLatString(...cameraPos);
-
-    if (ball.isOnScene()) {
-      toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos());
-    }
   }
 
   return { update };

--- a/examples/geojson/index.html
+++ b/examples/geojson/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
   <head>
     <title>Globelet - Beta</title>
@@ -14,10 +14,9 @@
 
   <body>
     <div id="globe"></div>
-  </body>
 
-  <script type="module">
-    import * as globeletjs from "../../dist/globelet.js";
+    <script type="module">
+      import * as globeletjs from "../../dist/globelet.js";
 
     globeletjs.initGlobe({
       container: 'globe',
@@ -42,5 +41,7 @@
         requestID = requestAnimationFrame(animate);
       }
     }).catch(console.log);
-  </script>
+    </script>
+  </body>
+
 </html>

--- a/examples/mapbox-streets/index.html
+++ b/examples/mapbox-streets/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
   <head>
     <title>Globelet - Beta</title>
@@ -14,10 +14,9 @@
 
   <body>
     <div id="globe"></div>
-  </body>
 
-  <script type="module">
-    import * as globeletjs from "../../dist/globelet.js";
+    <script type="module">
+      import * as globeletjs from "../../dist/globelet.js";
 
     globeletjs.initGlobe({
       container: 'globe',
@@ -27,5 +26,7 @@
       altitude: 6280,
     }).then(globe => globe.startAnimation())
       .catch(console.log);
-  </script>
+    </script>
+  </body>
+
 </html>

--- a/examples/mountains/index.html
+++ b/examples/mountains/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
   <head>
     <title>Globelet - Beta</title>
@@ -16,17 +16,16 @@
     <div id="globe">
       <div id="infobox"></div>
     </div>
-  </body>
 
-  <!-- "mountain-15" from https://github.com/mapbox/maki -->
-  <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 15 15">
-    <symbol id="mtIcon" viewBox="0 0 15 15">
+    <!-- "mountain-15" from https://github.com/mapbox/maki -->
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+      <symbol id="mtIcon" viewBox="0 0 15 15">
       <path id="path5571" d="M7.5,2C7.2,2,7.1,2.2,6.9,2.4&#xA;&#x9;l-5.8,9.5C1,12,1,12.2,1,12.3C1,12.8,1.4,13,1.7,13h11.6c0.4,0,0.7-0.2,0.7-0.7c0-0.2,0-0.2-0.1-0.4L8.2,2.4C8,2.2,7.8,2,7.5,2z&#xA;&#x9; M7.5,3.5L10.8,9H10L8.5,7.5L7.5,9l-1-1.5L5,9H4.1L7.5,3.5z" />
-    </symbol>
-  </svg>
+      </symbol>
+    </svg>
 
-  <script type="module">
-    import { initGlobe } from "../../dist/globelet.js";
+    <script type="module">
+      import { initGlobe } from "../../dist/globelet.js";
     import { initMountains } from "./mountains.js";
 
     initGlobe({
@@ -47,5 +46,7 @@
         requestAnimationFrame(animate);
       }
     }).catch(console.log);
-  </script>
+    </script>
+  </body>
+
 </html>

--- a/examples/mountains/styles.css
+++ b/examples/mountains/styles.css
@@ -1,9 +1,14 @@
+* {
+  box-sizing: border-box;
+}
 html {
   overflow: hidden;
-  height: 100%;
+  height: calc(100vh + 1px);
 }
 body {
+  position: fixed;
   height: 100%;
+  width: 100%;
   border: 0;
   margin: 0;
   touch-action: none;

--- a/examples/mountains/wiki-api.js
+++ b/examples/mountains/wiki-api.js
@@ -22,10 +22,23 @@ export function getWikiData(wikidataid) {
 function parseEntityData(data) {
   const { labels, descriptions, claims, sitelinks } = data;
 
-  const label = labels?.en?.value;
-  const description = descriptions?.en?.value;
-  const imagefile = claims?.P18?.[0]?.mainsnak?.datavalue?.value;
-  const sitelink = sitelinks?.enwiki?.url;
+  // All of these would be better done with optional chaining,
+  // but we do it clumsily to make sure we can run on old Androids
+  const label = (labels && labels.en)
+    ? labels.en.value
+    : undefined;
+  const description = (descriptions && descriptions.en)
+    ? descriptions.en.value
+    : undefined;
+  const mainsnak = (claims && claims.P18 && claims.P18[0])
+    ? claims.P18[0].mainsnak
+    : undefined;
+  const imagefile = (mainsnak && mainsnak.datavalue)
+    ? mainsnak.datavalue.value
+    : undefined;
+  const sitelink = (sitelinks && sitelinks.enwiki)
+    ? sitelinks.enwiki.url
+    : undefined;
 
   const image = (imagefile && imagefile.length)
     ? '<img src="' + getImageSrc(imagefile) + '">'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "globeletjs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "globeletjs",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "satellite-view": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "satellite-view": "^2.1.1",
         "spinning-ball": "^0.5.0",
-        "tile-setter": "^0.1.11",
+        "tile-setter": "^0.1.12",
         "yawgl": "^0.4.2"
       },
       "devDependencies": {
@@ -1235,17 +1235,17 @@
       "dev": true
     },
     "node_modules/tile-batch": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/tile-batch/-/tile-batch-0.0.2.tgz",
-      "integrity": "sha512-GJg/hJrRkH7ATZZ+KuUrjKxBLIq9Gd6Sr2G4JiyVjlKeT57wiSkaocpxG1VUBKb1rZK+6x++tmIcxaD01PK9TQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tile-batch/-/tile-batch-0.0.3.tgz",
+      "integrity": "sha512-zEWayYpASGdhTeAUgjJjxz8zDZZjKrOmY466sIpxWHeRBpVB34qpW4kRjDzDccFP2KPCgE01us80NSC2WBu0rw==",
       "dependencies": {
-        "tile-gl": "^0.5.0"
+        "tile-gl": "^0.5.1"
       }
     },
     "node_modules/tile-gl": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.5.0.tgz",
-      "integrity": "sha512-PfHHZdvbRxtr2o5Fx8DeS20L9XNqBfOnOqopMk/3MrBwSnevLhfwAgG6QVPsX9Uhr0VwGGsGdn9ZrFJV+Ut8DQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.5.1.tgz",
+      "integrity": "sha512-OP8Y9hj+sl5snRr6s7JJBLHXJnEVKiXB9GZZfTW/w4WbwqVZU0Zvsxwrf1xncGrJZW9bSPlKcwtIpj3igeX3Yg==",
       "dependencies": {
         "earcut": "^2.2.3",
         "rbush": "^3.0.1",
@@ -1287,13 +1287,13 @@
       }
     },
     "node_modules/tile-setter": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.1.11.tgz",
-      "integrity": "sha512-tj+TWyhQuIO2Um42AwjWDFcvAG2y7RDJN8yDTtmuj+MGzk6D9kSICyyL/GBpW2iETpuLGQHZj/snvMq0aT1mSA==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.1.12.tgz",
+      "integrity": "sha512-7D9YK+33cE/coNHIn6PxzmQmcSnvhEaaxzRdsyepnDCvVM59lhspSDrgUBSVY36Y/CUtclnQP3Bpotk3KKCxHA==",
       "dependencies": {
         "chunked-queue": "^0.1.4",
         "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-batch": "^0.0.2",
+        "tile-batch": "^0.0.3",
         "tile-rack": "^1.0.4",
         "tile-stencil": "^0.4.12",
         "tile-worker": "^0.1.8"
@@ -1316,6 +1316,14 @@
         "tile-batch": "^0.0.2",
         "tile-mixer": "^0.3.3",
         "tile-retriever": "^0.0.7"
+      }
+    },
+    "node_modules/tile-worker/node_modules/tile-batch": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/tile-batch/-/tile-batch-0.0.2.tgz",
+      "integrity": "sha512-GJg/hJrRkH7ATZZ+KuUrjKxBLIq9Gd6Sr2G4JiyVjlKeT57wiSkaocpxG1VUBKb1rZK+6x++tmIcxaD01PK9TQ==",
+      "dependencies": {
+        "tile-gl": "^0.5.0"
       }
     },
     "node_modules/touch-sampler": {
@@ -2335,17 +2343,17 @@
       "dev": true
     },
     "tile-batch": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/tile-batch/-/tile-batch-0.0.2.tgz",
-      "integrity": "sha512-GJg/hJrRkH7ATZZ+KuUrjKxBLIq9Gd6Sr2G4JiyVjlKeT57wiSkaocpxG1VUBKb1rZK+6x++tmIcxaD01PK9TQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tile-batch/-/tile-batch-0.0.3.tgz",
+      "integrity": "sha512-zEWayYpASGdhTeAUgjJjxz8zDZZjKrOmY466sIpxWHeRBpVB34qpW4kRjDzDccFP2KPCgE01us80NSC2WBu0rw==",
       "requires": {
-        "tile-gl": "^0.5.0"
+        "tile-gl": "^0.5.1"
       }
     },
     "tile-gl": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.5.0.tgz",
-      "integrity": "sha512-PfHHZdvbRxtr2o5Fx8DeS20L9XNqBfOnOqopMk/3MrBwSnevLhfwAgG6QVPsX9Uhr0VwGGsGdn9ZrFJV+Ut8DQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.5.1.tgz",
+      "integrity": "sha512-OP8Y9hj+sl5snRr6s7JJBLHXJnEVKiXB9GZZfTW/w4WbwqVZU0Zvsxwrf1xncGrJZW9bSPlKcwtIpj3igeX3Yg==",
       "requires": {
         "earcut": "^2.2.3",
         "rbush": "^3.0.1",
@@ -2384,13 +2392,13 @@
       }
     },
     "tile-setter": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.1.11.tgz",
-      "integrity": "sha512-tj+TWyhQuIO2Um42AwjWDFcvAG2y7RDJN8yDTtmuj+MGzk6D9kSICyyL/GBpW2iETpuLGQHZj/snvMq0aT1mSA==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.1.12.tgz",
+      "integrity": "sha512-7D9YK+33cE/coNHIn6PxzmQmcSnvhEaaxzRdsyepnDCvVM59lhspSDrgUBSVY36Y/CUtclnQP3Bpotk3KKCxHA==",
       "requires": {
         "chunked-queue": "^0.1.4",
         "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-batch": "^0.0.2",
+        "tile-batch": "^0.0.3",
         "tile-rack": "^1.0.4",
         "tile-stencil": "^0.4.12",
         "tile-worker": "^0.1.8"
@@ -2413,6 +2421,16 @@
         "tile-batch": "^0.0.2",
         "tile-mixer": "^0.3.3",
         "tile-retriever": "^0.0.7"
+      },
+      "dependencies": {
+        "tile-batch": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/tile-batch/-/tile-batch-0.0.2.tgz",
+          "integrity": "sha512-GJg/hJrRkH7ATZZ+KuUrjKxBLIq9Gd6Sr2G4JiyVjlKeT57wiSkaocpxG1VUBKb1rZK+6x++tmIcxaD01PK9TQ==",
+          "requires": {
+            "tile-gl": "^0.5.0"
+          }
+        }
       }
     },
     "touch-sampler": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,69 +10,29 @@
       "license": "MIT",
       "dependencies": {
         "satellite-view": "^2.1.1",
-        "spinning-ball": "^0.4.1",
-        "tile-setter": "^0.1.9",
-        "yawgl": "^0.4.0"
+        "spinning-ball": "^0.5.0",
+        "tile-setter": "^0.1.11",
+        "yawgl": "^0.4.2"
       },
       "devDependencies": {
-        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-commonjs": "^21.0.3",
         "@rollup/plugin-node-resolve": "^13.1.3",
-        "eslint": "^8.8.0",
+        "eslint": "^8.12.0",
         "eslint-config-globeletjs": "^0.0.6",
-        "rollup": "^2.67.1"
-      }
-    },
-    "../eslint-config-globeletjs": {
-      "version": "0.0.1",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "eslint": "^7.30.0"
-      }
-    },
-    "../eslint-globeletjs": {
-      "name": "eslint-config-globeletjs",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "eslint": "^7.30.0"
-      }
-    },
-    "../tile-setter": {
-      "version": "0.1.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "chunked-queue": "^0.1.4",
-        "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-gl": "^0.2.0",
-        "tile-mixer": "^0.1.3",
-        "tile-rack": "^1.0.4",
-        "tile-stencil": "^0.4.4"
-      },
-      "devDependencies": {
-        "@rollup/plugin-commonjs": "^19.0.0",
-        "@rollup/plugin-node-resolve": "^13.0.0",
-        "@turf/boolean-point-in-polygon": "^6.0.1",
-        "d3": "^6.2.0",
-        "eslint": "^7.30.0",
-        "eslint-config-globeletjs": "^0.0.6",
-        "rollup": "^2.52.8",
-        "yawgl": "^0.3.3"
+        "rollup": "^2.70.1"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.2.0",
+        "espree": "^9.3.1",
         "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
@@ -83,9 +43,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -102,16 +62,25 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
-    "node_modules/@rollup/plugin-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
-      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.3.tgz",
+      "integrity": "sha512-ThGfwyvcLc6cfP/MWxA5ACF+LZCvsuhUq7V5134Az1oQWsiC7lNpLT4mJI86WQunK7BYmpUiHmMk2Op6OAHs0g==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^3.0.8"
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
+        "rollup": "^2.38.3"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -151,6 +120,12 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -158,9 +133,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
-      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==",
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -277,9 +252,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -318,6 +293,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -339,9 +320,12 @@
       }
     },
     "node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
+      "integrity": "sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-tile": {
       "version": "1.0.0",
@@ -349,9 +333,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -366,9 +350,9 @@
       }
     },
     "node_modules/deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "node_modules/deepmerge": {
@@ -410,12 +394,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
-      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+      "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.0.5",
+        "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -423,10 +407,10 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.0",
+        "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.2.0",
-        "espree": "^9.3.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -468,9 +452,9 @@
       "dev": true
     },
     "node_modules/eslint-scope": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -508,32 +492,23 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/espree": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-      "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.1.0"
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -573,9 +548,9 @@
       }
     },
     "node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "node_modules/esutils": {
@@ -631,9 +606,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
-      "integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
     "node_modules/fs.realpath": {
@@ -679,9 +654,9 @@
       "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -711,9 +686,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -767,9 +742,9 @@
       "peer": true
     },
     "node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -817,9 +792,9 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -854,6 +829,15 @@
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -904,10 +888,19 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1004,9 +997,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -1070,13 +1063,17 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1116,9 +1113,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.67.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.1.tgz",
-      "integrity": "sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==",
+      "version": "2.70.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
+      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1167,10 +1164,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
     "node_modules/spinning-ball": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.4.1.tgz",
-      "integrity": "sha512-bH519QHcbcPhdBO4Ad8EGpOuc+rYhqdtD+lq8+EIv22mLhhbnPkyQZgWfrpJlZ37hrcUSFyXmqsxmjJkU0Uzdg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.5.0.tgz",
+      "integrity": "sha512-2Fa85m+yX0TjGBr7o0U8MlygvHnE9dfpxpDK7fSe+wflk96IEN5jn7O4qE/1AeE3Mg2zJrR3xeeW/D1ypRBI+Q==",
       "dependencies": {
         "gl-matrix": "^3.4.3",
         "touch-sampler": "^0.0.4",
@@ -1213,40 +1216,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/tile-batch": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/tile-batch/-/tile-batch-0.0.2.tgz",
+      "integrity": "sha512-GJg/hJrRkH7ATZZ+KuUrjKxBLIq9Gd6Sr2G4JiyVjlKeT57wiSkaocpxG1VUBKb1rZK+6x++tmIcxaD01PK9TQ==",
+      "dependencies": {
+        "tile-gl": "^0.5.0"
+      }
+    },
     "node_modules/tile-gl": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.4.11.tgz",
-      "integrity": "sha512-MtTC+emW8q9iUTMPGCLLEB/kFVVMQ/iXC+cFjmSvWDG+uzF7dnFYTUnzbGJvQ+hYTxDbEGaQslSp+1XimmmG3g==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.5.0.tgz",
+      "integrity": "sha512-PfHHZdvbRxtr2o5Fx8DeS20L9XNqBfOnOqopMk/3MrBwSnevLhfwAgG6QVPsX9Uhr0VwGGsGdn9ZrFJV+Ut8DQ==",
       "dependencies": {
         "earcut": "^2.2.3",
         "rbush": "^3.0.1",
-        "tile-labeler": "^0.6.5",
-        "tile-stencil": "^0.4.7"
+        "tile-labeler": "^0.8.1",
+        "tile-stencil": "^0.4.12"
       }
     },
     "node_modules/tile-labeler": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.6.5.tgz",
-      "integrity": "sha512-enWGxphdaOhIY6A9rHF8cej9VOC9bsXnfQlRcI0QV40F/IJv7S2BJDsUzIEx3NziCm33pgwDNLmKoEgTn9NbDQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.8.1.tgz",
+      "integrity": "sha512-lqQGoH2JzzeAy38GGuJWGXFjDnrPcHtIFhS8RZERX3UiGts5k8+1DOzg+4RDCRPmu3b76jc8KFtVXz/3Yu9huQ==",
       "dependencies": {
         "sdf-manager": "^0.0.10"
       }
     },
     "node_modules/tile-mixer": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tile-mixer/-/tile-mixer-0.3.2.tgz",
-      "integrity": "sha512-qH8b8Two+MXm/5YllCOrfeQFQ6FmMofEV18809/dVCMQwpaXUPWYPRtA5fgjLOavVVX7fdM3cjynpnOCYszJ4g==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/tile-mixer/-/tile-mixer-0.3.3.tgz",
+      "integrity": "sha512-3jRe+weHNNrEX2aBVwLGCX+7csmdGiE492StzhrzrYygQzo/3TSXyPu4btVld7mv7DDnJ4XDTGU0E90skL3RFg==",
       "dependencies": {
-        "tile-stencil": "^0.4.6"
-      },
-      "peerDependencies": {
-        "pbf-esm": "^4.0.1"
+        "tile-stencil": "^0.4.9"
       }
     },
     "node_modules/tile-rack": {
@@ -1255,9 +1275,9 @@
       "integrity": "sha512-CcSLVJB4S7vJU/EAtxGpCXXVTFihDv9wanIXnI/mMg7LLtM1EwvdJljJUmZvRAnxgom1shhySKVcIfevIH5iKA=="
     },
     "node_modules/tile-retriever": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tile-retriever/-/tile-retriever-0.0.5.tgz",
-      "integrity": "sha512-AzRvVCVVYGSQh7yvsUgCySJmxThuMFaQS7FIkdE25zJqhngjKErrf1eiDhASbhPGqPzHS7c2E5wWl+u3IRLqwA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/tile-retriever/-/tile-retriever-0.0.7.tgz",
+      "integrity": "sha512-8I8pLSVJbV+e65yENXZd/Yq/7qU7u0nIa/+9keua54yObX2L7AvTculUloj9Y16JpbuOaniYlxnPLDRrG1jqLw==",
       "dependencies": {
         "geojson-vt": "^3.2.1",
         "vector-tile-esm": "^2.1.3"
@@ -1267,35 +1287,35 @@
       }
     },
     "node_modules/tile-setter": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.1.9.tgz",
-      "integrity": "sha512-68oZS5heFmXiQjkvrn13FFREoQxwehMzrHNwJR/U5gXt9xdHo4Jt6BnlBS8NFQZwTzQw6uD4+KE7kzhyPkn9pQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.1.11.tgz",
+      "integrity": "sha512-tj+TWyhQuIO2Um42AwjWDFcvAG2y7RDJN8yDTtmuj+MGzk6D9kSICyyL/GBpW2iETpuLGQHZj/snvMq0aT1mSA==",
       "dependencies": {
         "chunked-queue": "^0.1.4",
         "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-gl": "^0.4.11",
+        "tile-batch": "^0.0.2",
         "tile-rack": "^1.0.4",
-        "tile-stencil": "^0.4.7",
-        "tile-worker": "^0.1.6"
+        "tile-stencil": "^0.4.12",
+        "tile-worker": "^0.1.8"
       }
     },
     "node_modules/tile-stencil": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.7.tgz",
-      "integrity": "sha512-GI1iD2HEnznmCfNT1neCSH45rMZwFzJl96e41PembORjlks8tC6GYbtJkkV5QjK1nu7gFATOZSIHVwkaEhXazA==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.12.tgz",
+      "integrity": "sha512-6ugxKPWYQLkVXj48nYWYbJzqtWNS0zzxQ+81Rn/UucCswPtyDla2qO+aO/6E6+XWbXdB6lT4enGZJDTPlh9zJg==",
       "dependencies": {
-        "d3-color": "^1.4.1"
+        "d3-color": "3.0.1"
       }
     },
     "node_modules/tile-worker": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/tile-worker/-/tile-worker-0.1.6.tgz",
-      "integrity": "sha512-L29MLg2mMsmyEV/LWP6CSihQm7TiqTM1knfAa3U+yV+c2JTyUgBR8QHKQiBHyvrTv1kx6eAaakIfMUtWhiQHEw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/tile-worker/-/tile-worker-0.1.8.tgz",
+      "integrity": "sha512-4piUlBC3VF/TaNRNaBsawi4zZxaIGHK/UWlO9nBLdHyz3KlCGXIxPsWUqFIc/BIHlfr2fzVEf8VtaFVK+vl3mg==",
       "dependencies": {
         "chunked-queue": "^0.1.4",
-        "tile-gl": "^0.4.11",
-        "tile-mixer": "^0.3.2",
-        "tile-retriever": "^0.0.5"
+        "tile-batch": "^0.0.2",
+        "tile-mixer": "^0.3.3",
+        "tile-retriever": "^0.0.7"
       }
     },
     "node_modules/touch-sampler": {
@@ -1378,9 +1398,9 @@
       "dev": true
     },
     "node_modules/yawgl": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.4.0.tgz",
-      "integrity": "sha512-yFpU8rT52YioodGmBVnAyhTcPyHHGdFWwBdX2L3jtQqFbuDKK4pSRKYl2TsipvnkfDHhx9POwd+uy5lFk+vxtA=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.4.2.tgz",
+      "integrity": "sha512-e6vT/0Par+O/V3MW2sr+yynH7kGwZ/JK7LMlFmkIEw5b5EOoPMIAb7pm19bs1sa4P4wKzC6z5EFf77opZiidKA=="
     },
     "node_modules/zero-timeout": {
       "version": "0.0.6",
@@ -1390,16 +1410,16 @@
   },
   "dependencies": {
     "@eslint/eslintrc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.2.0",
+        "espree": "^9.3.1",
         "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
@@ -1407,9 +1427,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -1423,13 +1443,19 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
-    "@rollup/plugin-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
-      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+    "@rollup/plugin-commonjs": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.3.tgz",
+      "integrity": "sha512-ThGfwyvcLc6cfP/MWxA5ACF+LZCvsuhUq7V5134Az1oQWsiC7lNpLT4mJI86WQunK7BYmpUiHmMk2Op6OAHs0g==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.8"
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -1455,6 +1481,14 @@
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
         "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
       }
     },
     "@types/estree": {
@@ -1464,9 +1498,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
-      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==",
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
     "@types/resolve": {
@@ -1553,9 +1587,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -1585,6 +1619,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1603,27 +1643,27 @@
       }
     },
     "d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
+      "integrity": "sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw=="
     },
     "d3-tile": {
       "version": "git+ssh://git@github.com/GlobeletJS/d3-tile.git#2f0d6e7f211453e36b13fe64e1e5449554277dcc",
       "from": "d3-tile@github:GlobeletJS/d3-tile"
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "deepmerge": {
@@ -1653,12 +1693,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
-      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+      "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.0.5",
+        "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -1666,10 +1706,10 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.0",
+        "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.2.0",
-        "espree": "^9.3.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1693,14 +1733,6 @@
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-          "dev": true
-        }
       }
     },
     "eslint-config-globeletjs": {
@@ -1710,9 +1742,9 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -1737,20 +1769,20 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
     "espree": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-      "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.1.0"
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "esquery": {
@@ -1778,9 +1810,9 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "esutils": {
@@ -1827,9 +1859,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
-      "integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
     "fs.realpath": {
@@ -1868,9 +1900,9 @@
       "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1891,9 +1923,9 @@
       }
     },
     "globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -1921,9 +1953,9 @@
       "peer": true
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "import-fresh": {
@@ -1959,9 +1991,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -1987,6 +2019,15 @@
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
+    },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -2031,10 +2072,19 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -2113,9 +2163,9 @@
       }
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "potpack": {
@@ -2161,13 +2211,14 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -2195,9 +2246,9 @@
       }
     },
     "rollup": {
-      "version": "2.67.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.1.tgz",
-      "integrity": "sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==",
+      "version": "2.70.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
+      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -2231,10 +2282,16 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
     "spinning-ball": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.4.1.tgz",
-      "integrity": "sha512-bH519QHcbcPhdBO4Ad8EGpOuc+rYhqdtD+lq8+EIv22mLhhbnPkyQZgWfrpJlZ37hrcUSFyXmqsxmjJkU0Uzdg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/spinning-ball/-/spinning-ball-0.5.0.tgz",
+      "integrity": "sha512-2Fa85m+yX0TjGBr7o0U8MlygvHnE9dfpxpDK7fSe+wflk96IEN5jn7O4qE/1AeE3Mg2zJrR3xeeW/D1ypRBI+Q==",
       "requires": {
         "gl-matrix": "^3.4.3",
         "touch-sampler": "^0.0.4",
@@ -2265,37 +2322,51 @@
         "has-flag": "^4.0.0"
       }
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "tile-batch": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/tile-batch/-/tile-batch-0.0.2.tgz",
+      "integrity": "sha512-GJg/hJrRkH7ATZZ+KuUrjKxBLIq9Gd6Sr2G4JiyVjlKeT57wiSkaocpxG1VUBKb1rZK+6x++tmIcxaD01PK9TQ==",
+      "requires": {
+        "tile-gl": "^0.5.0"
+      }
+    },
     "tile-gl": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.4.11.tgz",
-      "integrity": "sha512-MtTC+emW8q9iUTMPGCLLEB/kFVVMQ/iXC+cFjmSvWDG+uzF7dnFYTUnzbGJvQ+hYTxDbEGaQslSp+1XimmmG3g==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/tile-gl/-/tile-gl-0.5.0.tgz",
+      "integrity": "sha512-PfHHZdvbRxtr2o5Fx8DeS20L9XNqBfOnOqopMk/3MrBwSnevLhfwAgG6QVPsX9Uhr0VwGGsGdn9ZrFJV+Ut8DQ==",
       "requires": {
         "earcut": "^2.2.3",
         "rbush": "^3.0.1",
-        "tile-labeler": "^0.6.5",
-        "tile-stencil": "^0.4.7"
+        "tile-labeler": "^0.8.1",
+        "tile-stencil": "^0.4.12"
       }
     },
     "tile-labeler": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.6.5.tgz",
-      "integrity": "sha512-enWGxphdaOhIY6A9rHF8cej9VOC9bsXnfQlRcI0QV40F/IJv7S2BJDsUzIEx3NziCm33pgwDNLmKoEgTn9NbDQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/tile-labeler/-/tile-labeler-0.8.1.tgz",
+      "integrity": "sha512-lqQGoH2JzzeAy38GGuJWGXFjDnrPcHtIFhS8RZERX3UiGts5k8+1DOzg+4RDCRPmu3b76jc8KFtVXz/3Yu9huQ==",
       "requires": {
         "sdf-manager": "^0.0.10"
       }
     },
     "tile-mixer": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tile-mixer/-/tile-mixer-0.3.2.tgz",
-      "integrity": "sha512-qH8b8Two+MXm/5YllCOrfeQFQ6FmMofEV18809/dVCMQwpaXUPWYPRtA5fgjLOavVVX7fdM3cjynpnOCYszJ4g==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/tile-mixer/-/tile-mixer-0.3.3.tgz",
+      "integrity": "sha512-3jRe+weHNNrEX2aBVwLGCX+7csmdGiE492StzhrzrYygQzo/3TSXyPu4btVld7mv7DDnJ4XDTGU0E90skL3RFg==",
       "requires": {
-        "tile-stencil": "^0.4.6"
+        "tile-stencil": "^0.4.9"
       }
     },
     "tile-rack": {
@@ -2304,44 +2375,44 @@
       "integrity": "sha512-CcSLVJB4S7vJU/EAtxGpCXXVTFihDv9wanIXnI/mMg7LLtM1EwvdJljJUmZvRAnxgom1shhySKVcIfevIH5iKA=="
     },
     "tile-retriever": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tile-retriever/-/tile-retriever-0.0.5.tgz",
-      "integrity": "sha512-AzRvVCVVYGSQh7yvsUgCySJmxThuMFaQS7FIkdE25zJqhngjKErrf1eiDhASbhPGqPzHS7c2E5wWl+u3IRLqwA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/tile-retriever/-/tile-retriever-0.0.7.tgz",
+      "integrity": "sha512-8I8pLSVJbV+e65yENXZd/Yq/7qU7u0nIa/+9keua54yObX2L7AvTculUloj9Y16JpbuOaniYlxnPLDRrG1jqLw==",
       "requires": {
         "geojson-vt": "^3.2.1",
         "vector-tile-esm": "^2.1.3"
       }
     },
     "tile-setter": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.1.9.tgz",
-      "integrity": "sha512-68oZS5heFmXiQjkvrn13FFREoQxwehMzrHNwJR/U5gXt9xdHo4Jt6BnlBS8NFQZwTzQw6uD4+KE7kzhyPkn9pQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/tile-setter/-/tile-setter-0.1.11.tgz",
+      "integrity": "sha512-tj+TWyhQuIO2Um42AwjWDFcvAG2y7RDJN8yDTtmuj+MGzk6D9kSICyyL/GBpW2iETpuLGQHZj/snvMq0aT1mSA==",
       "requires": {
         "chunked-queue": "^0.1.4",
         "d3-tile": "github:GlobeletJS/d3-tile",
-        "tile-gl": "^0.4.11",
+        "tile-batch": "^0.0.2",
         "tile-rack": "^1.0.4",
-        "tile-stencil": "^0.4.7",
-        "tile-worker": "^0.1.6"
+        "tile-stencil": "^0.4.12",
+        "tile-worker": "^0.1.8"
       }
     },
     "tile-stencil": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.7.tgz",
-      "integrity": "sha512-GI1iD2HEnznmCfNT1neCSH45rMZwFzJl96e41PembORjlks8tC6GYbtJkkV5QjK1nu7gFATOZSIHVwkaEhXazA==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/tile-stencil/-/tile-stencil-0.4.12.tgz",
+      "integrity": "sha512-6ugxKPWYQLkVXj48nYWYbJzqtWNS0zzxQ+81Rn/UucCswPtyDla2qO+aO/6E6+XWbXdB6lT4enGZJDTPlh9zJg==",
       "requires": {
-        "d3-color": "^1.4.1"
+        "d3-color": "3.0.1"
       }
     },
     "tile-worker": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/tile-worker/-/tile-worker-0.1.6.tgz",
-      "integrity": "sha512-L29MLg2mMsmyEV/LWP6CSihQm7TiqTM1knfAa3U+yV+c2JTyUgBR8QHKQiBHyvrTv1kx6eAaakIfMUtWhiQHEw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/tile-worker/-/tile-worker-0.1.8.tgz",
+      "integrity": "sha512-4piUlBC3VF/TaNRNaBsawi4zZxaIGHK/UWlO9nBLdHyz3KlCGXIxPsWUqFIc/BIHlfr2fzVEf8VtaFVK+vl3mg==",
       "requires": {
         "chunked-queue": "^0.1.4",
-        "tile-gl": "^0.4.11",
-        "tile-mixer": "^0.3.2",
-        "tile-retriever": "^0.0.5"
+        "tile-batch": "^0.0.2",
+        "tile-mixer": "^0.3.3",
+        "tile-retriever": "^0.0.7"
       }
     },
     "touch-sampler": {
@@ -2406,9 +2477,9 @@
       "dev": true
     },
     "yawgl": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.4.0.tgz",
-      "integrity": "sha512-yFpU8rT52YioodGmBVnAyhTcPyHHGdFWwBdX2L3jtQqFbuDKK4pSRKYl2TsipvnkfDHhx9POwd+uy5lFk+vxtA=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.4.2.tgz",
+      "integrity": "sha512-e6vT/0Par+O/V3MW2sr+yynH7kGwZ/JK7LMlFmkIEw5b5EOoPMIAb7pm19bs1sa4P4wKzC6z5EFf77opZiidKA=="
     },
     "zero-timeout": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   },
   "homepage": "https://globeletjs.org",
   "devDependencies": {
-    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-commonjs": "^21.0.3",
     "@rollup/plugin-node-resolve": "^13.1.3",
-    "eslint": "^8.8.0",
+    "eslint": "^8.12.0",
     "eslint-config-globeletjs": "^0.0.6",
-    "rollup": "^2.67.1"
+    "rollup": "^2.70.1"
   },
   "dependencies": {
     "satellite-view": "^2.1.1",
-    "spinning-ball": "^0.4.1",
-    "tile-setter": "^0.1.9",
-    "yawgl": "^0.4.0"
+    "spinning-ball": "^0.5.0",
+    "tile-setter": "^0.1.11",
+    "yawgl": "^0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "satellite-view": "^2.1.1",
     "spinning-ball": "^0.5.0",
-    "tile-setter": "^0.1.11",
+    "tile-setter": "^0.1.12",
     "yawgl": "^0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "globeletjs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Lightweight vector maps on a globe",
   "main": "dist/globelet-iife.js",
   "module": "dist/globelet.js",

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -8,10 +8,6 @@ export function initToolTip(ball, globeDiv) {
     const cameraPos = ball.cameraPos();
     const alt = cameraPos[2].toPrecision(5);
     toolTip.innerHTML = alt + "km " + lonLatString(...cameraPos);
-
-    if (ball.isOnScene()) {
-      toolTip.innerHTML += "<br> Cursor: " + lonLatString(...ball.cursorPos());
-    }
   }
 
   return { update };


### PR DESCRIPTION
This addresses the problems raised in #20.

The main problems were coming from [yawgl](https://github.com/GlobeletJS/yawgl) via [tile-gl](https://github.com/GlobeletJS/tile-gl). Some Android phones return information about shader uniforms in an unexpected order. On these phones, style properties were being sent to the wrong variable.

During the debug process, tile-gl was also refactored to pare it down to a pure tile rendering module. Code relating to multi-tile tilesets was moved out into the new module [tile-batch](https://github.com/GlobeletJS/tile-batch).

The example HTML/CSS was also edited to make better use of mobile screen space&mdash;including when the available screen area changes due to appearing/disappearing address bars.