### PR TITLE
Update GLSL: no samplers in function arguments

### DIFF
--- a/dist/globelet-iife.js
+++ b/dist/globelet-iife.js
@@ -301,6 +301,7 @@ var globeletjs = (function (exports) {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
       const log = gl.getShaderInfoLog(shader);
       gl.deleteShader(shader);
+      console.log("shader source = " + source);
       fail$3("An error occured compiling the shader", log);
     }
 
@@ -647,8 +648,8 @@ bool inside(vec2 pos) {
       0.001 < pos.y && pos.y < 0.999 );
 }
 
-vec4 sampleLOD(sampler2D samplers[nLod], vec2 coords[nLod]) {
-  return ${args.buildSelector}texture(samplers[0], coords[0]);
+vec4 sampleLOD(vec2 coords[nLod]) {
+  return ${args.buildSelector}texture(uTextureSampler[0], coords[0]);
 }
 
 vec4 texLookup(vec2 dMerc) {
@@ -659,7 +660,7 @@ vec4 texLookup(vec2 dMerc) {
     texCoords[i].x = dateline(texCoords[i].x);
   }
 
-  return sampleLOD(uTextureSampler, texCoords);
+  return sampleLOD(texCoords);
 }
 `;
 
@@ -769,7 +770,7 @@ precision highp sampler2D;
     // and sample the highest LOD that contains the current coordinate
     let selector = ``; // eslint-disable-line quotes
     while (--n) selector += `inside(coords[${n}])
-    ? texture(samplers[${n}], coords[${n}])
+    ? texture(uTextureSampler[${n}], coords[${n}])
     : `;
     return selector;
   }

--- a/dist/globelet.js
+++ b/dist/globelet.js
@@ -298,6 +298,7 @@ function loadShader(gl, type, source) {
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
     const log = gl.getShaderInfoLog(shader);
     gl.deleteShader(shader);
+    console.log("shader source = " + source);
     fail$3("An error occured compiling the shader", log);
   }
 
@@ -644,8 +645,8 @@ bool inside(vec2 pos) {
       0.001 < pos.y && pos.y < 0.999 );
 }
 
-vec4 sampleLOD(sampler2D samplers[nLod], vec2 coords[nLod]) {
-  return ${args.buildSelector}texture(samplers[0], coords[0]);
+vec4 sampleLOD(vec2 coords[nLod]) {
+  return ${args.buildSelector}texture(uTextureSampler[0], coords[0]);
 }
 
 vec4 texLookup(vec2 dMerc) {
@@ -656,7 +657,7 @@ vec4 texLookup(vec2 dMerc) {
     texCoords[i].x = dateline(texCoords[i].x);
   }
 
-  return sampleLOD(uTextureSampler, texCoords);
+  return sampleLOD(texCoords);
 }
 `;
 
@@ -766,7 +767,7 @@ function buildSelector(n) {
   // and sample the highest LOD that contains the current coordinate
   let selector = ``; // eslint-disable-line quotes
   while (--n) selector += `inside(coords[${n}])
-    ? texture(samplers[${n}], coords[${n}])
+    ? texture(uTextureSampler[${n}], coords[${n}])
     : `;
   return selector;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "globeletjs",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "globeletjs",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "satellite-view": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
-        "satellite-view": "^2.1.1",
+        "satellite-view": "^2.1.2",
         "spinning-ball": "^0.5.0",
         "tile-setter": "^0.1.12",
-        "yawgl": "^0.4.2"
+        "yawgl": "^0.4.3"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.3",
@@ -1128,9 +1128,9 @@
       }
     },
     "node_modules/satellite-view": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.1.1.tgz",
-      "integrity": "sha512-h8Vd4Klxa5oOhHdeGgcPR3E/xcYHbZ34QsK6CmOfQRMzkNy3qx54VOaz0VzHJm13bgavd03xI/dLhV7nazLntg=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.1.2.tgz",
+      "integrity": "sha512-pZdVvYEqdh7iT3utbzJU3FM2bP2ypFg8SYtJRZxtcJVW4+eRBYxmvTY7vEwnbuEt78ncURJTid0v65ZptGqMpA=="
     },
     "node_modules/sdf-manager": {
       "version": "0.0.10",
@@ -1406,9 +1406,9 @@
       "dev": true
     },
     "node_modules/yawgl": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.4.2.tgz",
-      "integrity": "sha512-e6vT/0Par+O/V3MW2sr+yynH7kGwZ/JK7LMlFmkIEw5b5EOoPMIAb7pm19bs1sa4P4wKzC6z5EFf77opZiidKA=="
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.4.3.tgz",
+      "integrity": "sha512-KDrjTp86FGCmLgNOjTNt5MGDs0AtRWrANxYZjyNYpHfn9wvYmAOELLL0raSqC+wXZLMam4AxIf37EbCdlq2UHQ=="
     },
     "node_modules/zero-timeout": {
       "version": "0.0.6",
@@ -2263,9 +2263,9 @@
       }
     },
     "satellite-view": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.1.1.tgz",
-      "integrity": "sha512-h8Vd4Klxa5oOhHdeGgcPR3E/xcYHbZ34QsK6CmOfQRMzkNy3qx54VOaz0VzHJm13bgavd03xI/dLhV7nazLntg=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/satellite-view/-/satellite-view-2.1.2.tgz",
+      "integrity": "sha512-pZdVvYEqdh7iT3utbzJU3FM2bP2ypFg8SYtJRZxtcJVW4+eRBYxmvTY7vEwnbuEt78ncURJTid0v65ZptGqMpA=="
     },
     "sdf-manager": {
       "version": "0.0.10",
@@ -2495,9 +2495,9 @@
       "dev": true
     },
     "yawgl": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.4.2.tgz",
-      "integrity": "sha512-e6vT/0Par+O/V3MW2sr+yynH7kGwZ/JK7LMlFmkIEw5b5EOoPMIAb7pm19bs1sa4P4wKzC6z5EFf77opZiidKA=="
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/yawgl/-/yawgl-0.4.3.tgz",
+      "integrity": "sha512-KDrjTp86FGCmLgNOjTNt5MGDs0AtRWrANxYZjyNYpHfn9wvYmAOELLL0raSqC+wXZLMam4AxIf37EbCdlq2UHQ=="
     },
     "zero-timeout": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "rollup": "^2.70.1"
   },
   "dependencies": {
-    "satellite-view": "^2.1.1",
+    "satellite-view": "^2.1.2",
     "spinning-ball": "^0.5.0",
     "tile-setter": "^0.1.12",
-    "yawgl": "^0.4.2"
+    "yawgl": "^0.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "globeletjs",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Lightweight vector maps on a globe",
   "main": "dist/globelet-iife.js",
   "module": "dist/globelet.js",


### PR DESCRIPTION
On some Android devices, gl.compileShader was complaining about a texture sampler in a function argument.

The relevant code in satellite-view was updated to use the global name for the sampler uniforms.

The updated code fixes #20 for our remaining test phones.